### PR TITLE
Refactor index and signup pages to use base template

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,132 +1,103 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Course Planner - Sign In</title>
+{% extends "base.html" %}
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}">
-</head>
+{% block title %}Course Planner - Sign In{% endblock %}
 
-<body class="auth-page">
-    <header class="auth-header">
-        <div class="container auth-nav">
-            <div class="brand">
-                <span class="brand-icon glyphicon glyphicon-calendar"></span>
-                <span class="brand-name">Course Planner</span>
-            </div>
+{% block nav %}
+<nav class="auth-links">
+    <a href="{{ url_for('index') }}" class="active">Sign In</a>
+    <a href="{{ url_for('signup') }}">Sign Up</a>
+    <a href="#features">Features</a>
+</nav>
+{% endblock %}
 
-            <nav class="auth-links">
-                <a href="{{ url_for('index') }}" class="active">Sign In</a>
-                <a href="{{ url_for('signup') }}">Sign Up</a>
-                <a href="#features">Features</a>
-            </nav>
+{% block content %}
+<div class="auth-main">
+    <div class="container">
+        <div class="auth-layout">
+            <section class="auth-hero">
+                <p class="eyebrow-text">Semester planning made simpler</p>
 
-            <button type="button" class="theme-toggle" onclick="toggleDarkMode()" aria-label="Toggle dark mode" aria-pressed="false">
-                <span class="theme-toggle-label">Dark</span>
-                <span class="theme-toggle-thumb"></span>
-            </button>
+                <h1>Build your course plan with confidence.</h1>
+
+                <p class="hero-description">
+                    Select your degree, explore available courses, organise your timetable,
+                    and compare study plans with other students before finalising your semester.
+                </p>
+
+                <div class="hero-actions">
+                    <button type="button" class="btn hero-btn-primary" onclick="goToSignUp()">
+                        Create Account
+                    </button>
+
+                    <a href="#features" class="hero-link">View Features</a>
+                </div>
+
+                <div id="features" class="feature-grid">
+                    <div class="feature-card">
+                        <span class="glyphicon glyphicon-list-alt"></span>
+                        <h3>Browse Courses</h3>
+                        <p>View course codes, credit points, and scheduling details in one place.</p>
+                    </div>
+
+                    <div class="feature-card">
+                        <span class="glyphicon glyphicon-time"></span>
+                        <h3>Plan Timetables</h3>
+                        <p>Create a structured weekly timetable based on your selected courses.</p>
+                    </div>
+
+                    <div class="feature-card">
+                        <span class="glyphicon glyphicon-stats"></span>
+                        <h3>Track Demand</h3>
+                        <p>Support administrators with basic enrolment and course demand insights.</p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="signin-card">
+                <div class="signin-card-header">
+                    <h2>Welcome back</h2>
+                    <p>Sign in to continue planning your semester.</p>
+                </div>
+
+                {% with messages = get_flashed_messages(with_categories=true) %}
+                    {% if messages %}
+                        <div class="signin-output">
+                            {% for category, message in messages %}
+                                <p class="flash-message {{ category }}">{{ message }}</p>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                {% endwith %}
+
+                <form id="signin-form" method="POST" action="{{ url_for('index') }}">
+                    <div class="form-group">
+                        <label for="user-email">Email Address</label>
+                        <input type="email" id="user-email" name="email" class="form-control" placeholder="Enter your email address">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="user-password">Password</label>
+                        <input type="password" id="user-password" name="password" class="form-control" placeholder="Enter your password">
+                    </div>
+
+                    <button type="submit" class="btn signin-btn">
+                        <span class="glyphicon glyphicon-log-in"></span>
+                        Sign In
+                    </button>
+
+                    <button type="button" class="btn forgot-btn" onclick="goToForgotPassword()">
+                        Forgot Password?
+                    </button>
+                </form>
+
+                <div class="signup-prompt">
+                    <p>New to Course Planner?</p>
+                    <button type="button" class="btn signup-btn" onclick="goToSignUp()">
+                        Create an account
+                    </button>
+                </div>
+            </section>
         </div>
-    </header>
-
-    <main class="auth-main">
-        <div class="container">
-            <div class="auth-layout">
-                <section class="auth-hero">
-                    <p class="eyebrow-text">Semester planning made simpler</p>
-
-                    <h1>Build your course plan with confidence.</h1>
-
-                    <p class="hero-description">
-                        Select your degree, explore available courses, organise your timetable,
-                        and compare study plans with other students before finalising your semester.
-                    </p>
-
-                    <div class="hero-actions">
-                        <button type="button" class="btn hero-btn-primary" onclick="goToSignUp()">
-                            Create Account
-                        </button>
-
-                        <a href="#features" class="hero-link">View Features</a>
-                    </div>
-
-                    <div id="features" class="feature-grid">
-                        <div class="feature-card">
-                            <span class="glyphicon glyphicon-list-alt"></span>
-                            <h3>Browse Courses</h3>
-                            <p>View course codes, credit points, and scheduling details in one place.</p>
-                        </div>
-
-                        <div class="feature-card">
-                            <span class="glyphicon glyphicon-time"></span>
-                            <h3>Plan Timetables</h3>
-                            <p>Create a structured weekly timetable based on your selected courses.</p>
-                        </div>
-
-                        <div class="feature-card">
-                            <span class="glyphicon glyphicon-stats"></span>
-                            <h3>Track Demand</h3>
-                            <p>Support administrators with basic enrolment and course demand insights.</p>
-                        </div>
-                    </div>
-                </section>
-
-                <section class="signin-card">
-                    <div class="signin-card-header">
-                        <h2>Welcome back</h2>
-                        <p>Sign in to continue planning your semester.</p>
-                    </div>
-
-                    {% with messages = get_flashed_messages(with_categories=true) %}
-                        {% if messages %}
-                            <div class="signin-output">
-                                {% for category, message in messages %}
-                                    <p class="flash-message {{ category }}">{{ message }}</p>
-                                {% endfor %}
-                            </div>
-                        {% endif %}
-                    {% endwith %}
-
-                    <form id="signin-form" method="POST" action="{{ url_for('index') }}">
-                        <div class="form-group">
-                            <label for="user-email">Email Address</label>
-                            <input type="email" id="user-email" name="email" class="form-control" placeholder="Enter your email address">
-                        </div>
-
-                        <div class="form-group">
-                            <label for="user-password">Password</label>
-                            <input type="password" id="user-password" name="password" class="form-control" placeholder="Enter your password">
-                        </div>
-
-                        <button type="submit" class="btn signin-btn">
-                            <span class="glyphicon glyphicon-log-in"></span>
-                            Sign In
-                        </button>
-
-                        <button type="button" class="btn forgot-btn" onclick="goToForgotPassword()">
-                            Forgot Password?
-                        </button>
-                    </form>
-
-                    <div class="signup-prompt">
-                        <p>New to Course Planner?</p>
-                        <button type="button" class="btn signup-btn" onclick="goToSignUp()">
-                            Create an account
-                        </button>
-                    </div>
-                </section>
-            </div>
-        </div>
-    </main>
-
-    <footer class="auth-footer">
-        <div class="container">
-            <p>Created for the Agile Web Development Group Project.</p>
-        </div>
-    </footer>
-
-    <script src="{{ url_for('static', filename='js/script.js') }}"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js"></script>
-</body>
-</html>
+    </div>
+</div>
+{% endblock %}

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,132 +1,103 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Course Planner - Sign Up</title>
+{% extends "base.html" %}
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}">
-</head>
+{% block title %}Course Planner - Sign Up{% endblock %}
 
-<body class="auth-page">
-    <header class="auth-header">
-        <div class="container auth-nav">
-            <div class="brand">
-                <span class="brand-icon glyphicon glyphicon-calendar"></span>
-                <span class="brand-name">Course Planner</span>
-            </div>
+{% block nav %}
+<nav class="auth-links">
+    <a href="{{ url_for('index') }}">Sign In</a>
+    <a href="{{ url_for('signup') }}" class="active">Sign Up</a>
+    <a href="{{ url_for('index') }}#features">Features</a>
+</nav>
+{% endblock %}
 
-            <nav class="auth-links">
-                <a href="{{ url_for('index') }}">Sign In</a>
-                <a href="{{ url_for('signup') }}" class="active">Sign Up</a>
-                <a href="{{ url_for('index') }}#features">Features</a>
-            </nav>
+{% block content %}
+<div class="auth-main">
+    <div class="container">
+        <div class="auth-layout signup-layout">
+            <section class="auth-hero">
+                <p class="eyebrow-text">Create your study planning account</p>
 
-            <button type="button" class="theme-toggle" onclick="toggleDarkMode()" aria-label="Toggle dark mode" aria-pressed="false">
-                <span class="theme-toggle-label">Dark</span>
-                <span class="theme-toggle-thumb"></span>
-            </button>
-        </div>
-    </header>
+                <h1>Start organising your semester in one place.</h1>
 
-    <main class="auth-main">
-        <div class="container">
-            <div class="auth-layout signup-layout">
-                <section class="auth-hero">
-                    <p class="eyebrow-text">Create your study planning account</p>
+                <p class="hero-description">
+                    Create an account to save your course selections, prepare your timetable,
+                    and manage your study planning more easily throughout the semester.
+                </p>
 
-                    <h1>Start organising your semester in one place.</h1>
-
-                    <p class="hero-description">
-                        Create an account to save your course selections, prepare your timetable,
-                        and manage your study planning more easily throughout the semester.
-                    </p>
-
-                    <div class="feature-grid signup-feature-grid">
-                        <div class="feature-card">
-                            <span class="glyphicon glyphicon-education"></span>
-                            <h3>Select Degree</h3>
-                            <p>Choose your degree pathway and browse courses relevant to your study plan.</p>
-                        </div>
-
-                        <div class="feature-card">
-                            <span class="glyphicon glyphicon-check"></span>
-                            <h3>Save Courses</h3>
-                            <p>Add preferred courses to your plan and keep track of your selections.</p>
-                        </div>
-
-                        <div class="feature-card">
-                            <span class="glyphicon glyphicon-calendar"></span>
-                            <h3>Build Timetable</h3>
-                            <p>Use your selected courses to create a clearer weekly timetable structure.</p>
-                        </div>
-                    </div>
-                </section>
-
-                <section class="signin-card signup-card">
-                    <div class="signin-card-header">
-                        <h2>Create account</h2>
-                        <p>Enter your details to begin using Course Planner.</p>
+                <div class="feature-grid signup-feature-grid">
+                    <div class="feature-card">
+                        <span class="glyphicon glyphicon-education"></span>
+                        <h3>Select Degree</h3>
+                        <p>Choose your degree pathway and browse courses relevant to your study plan.</p>
                     </div>
 
-                    {% with messages = get_flashed_messages(with_categories=true) %}
-                        {% if messages %}
-                            <div class="signin-output">
-                                {% for category, message in messages %}
-                                    <p class="flash-message {{ category }}">{{ message }}</p>
-                                {% endfor %}
-                            </div>
-                        {% endif %}
-                    {% endwith %}
+                    <div class="feature-card">
+                        <span class="glyphicon glyphicon-check"></span>
+                        <h3>Save Courses</h3>
+                        <p>Add preferred courses to your plan and keep track of your selections.</p>
+                    </div>
 
-                    <form id="signup-form" method="POST" action="{{ url_for('signup') }}">
-                        <div class="form-group">
-                            <label for="full-name">Full Name</label>
-                            <input type="text" id="full-name" name="full_name" class="form-control" placeholder="Enter your full name">
+                    <div class="feature-card">
+                        <span class="glyphicon glyphicon-calendar"></span>
+                        <h3>Build Timetable</h3>
+                        <p>Use your selected courses to create a clearer weekly timetable structure.</p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="signin-card signup-card">
+                <div class="signin-card-header">
+                    <h2>Create account</h2>
+                    <p>Enter your details to begin using Course Planner.</p>
+                </div>
+
+                {% with messages = get_flashed_messages(with_categories=true) %}
+                    {% if messages %}
+                        <div class="signin-output">
+                            {% for category, message in messages %}
+                                <p class="flash-message {{ category }}">{{ message }}</p>
+                            {% endfor %}
                         </div>
+                    {% endif %}
+                {% endwith %}
 
-                        <div class="form-group">
-                            <label for="signup-email">Email Address</label>
-                            <input type="email" id="signup-email" name="email" class="form-control" placeholder="Enter your email address">
-                        </div>
+                <form id="signup-form" method="POST" action="{{ url_for('signup') }}">
+                    <div class="form-group">
+                        <label for="full-name">Full Name</label>
+                        <input type="text" id="full-name" name="full_name" class="form-control" placeholder="Enter your full name">
+                    </div>
 
-                        <div class="form-group">
-                            <label for="student-id">Student ID</label>
-                            <input type="text" id="student-id" name="student_id" class="form-control" placeholder="Enter your student ID">
-                        </div>
+                    <div class="form-group">
+                        <label for="signup-email">Email Address</label>
+                        <input type="email" id="signup-email" name="email" class="form-control" placeholder="Enter your email address">
+                    </div>
 
-                        <div class="form-group">
-                            <label for="signup-password">Password</label>
-                            <input type="password" id="signup-password" name="password" class="form-control" placeholder="Create a password">
-                        </div>
+                    <div class="form-group">
+                        <label for="student-id">Student ID</label>
+                        <input type="text" id="student-id" name="student_id" class="form-control" placeholder="Enter your student ID">
+                    </div>
 
-                        <div class="form-group">
-                            <label for="confirm-password">Confirm Password</label>
-                            <input type="password" id="confirm-password" name="confirm_password" class="form-control" placeholder="Re-enter your password">
-                        </div>
+                    <div class="form-group">
+                        <label for="signup-password">Password</label>
+                        <input type="password" id="signup-password" name="password" class="form-control" placeholder="Create a password">
+                    </div>
 
-                        <button type="submit" class="btn signin-btn">
-                            <span class="glyphicon glyphicon-user"></span>
-                            Create Account
-                        </button>
+                    <div class="form-group">
+                        <label for="confirm-password">Confirm Password</label>
+                        <input type="password" id="confirm-password" name="confirm_password" class="form-control" placeholder="Re-enter your password">
+                    </div>
 
-                        <button type="button" class="btn forgot-btn" onclick="goToSignIn()">
-                            Already have an account? Sign in
-                        </button>
-                    </form>
-                </section>
-            </div>
+                    <button type="submit" class="btn signin-btn">
+                        <span class="glyphicon glyphicon-user"></span>
+                        Create Account
+                    </button>
+
+                    <button type="button" class="btn forgot-btn" onclick="goToSignIn()">
+                        Already have an account? Sign in
+                    </button>
+                </form>
+            </section>
         </div>
-    </main>
-
-    <footer class="auth-footer">
-        <div class="container">
-            <p>Created for the Agile Web Development Group Project.</p>
-        </div>
-    </footer>
-
-    <script src="{{ url_for('static', filename='js/script.js') }}"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js"></script>
-</body>
-</html>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR completes the YongheHu part of issue #44.

Changes made:
- Refactored templates/index.html to extend base.html
- Refactored templates/signup.html to extend base.html
- Moved page-specific content into Jinja content blocks
- Removed duplicated page-level HTML structure from both pages
- Checked that both pages still render with the shared layout

Refs #44