### PR TITLE
Fix homepage layout regression after feature cards removal

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -659,7 +659,7 @@ footer p {
     display: flex;
     align-items: center;
     gap: 18px;
-    margin-bottom: 0;
+    margin-bottom: 34px;
 }
 .hero-btn-primary,
 .signin-btn {

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,6 @@
 <nav class="auth-links">
     <a href="{{ url_for('index') }}" class="active">{{ _('Sign In') }}</a>
     <a href="{{ url_for('signup') }}">{{ _('Sign Up') }}</a>
-    
     <a href="{{ url_for('admin_login') }}">{{ _('Admin Login') }}</a>
 </nav>
 {% endblock %}
@@ -28,22 +27,6 @@
                     <button type="button" class="btn hero-btn-primary" onclick="goToSignUp()">
                         {{ _('Create Account') }}
                     </button>
-
-                    
-                </div>
-
-
-                    <div class="feature-card">
-                        <span class="glyphicon glyphicon-time"></span>
-                        <h3>{{ _('Plan Timetables') }}</h3>
-                        <p>{{ _('Create a structured weekly timetable based on your selected courses.') }}</p>
-                    </div>
-
-                    <div class="feature-card">
-                        <span class="glyphicon glyphicon-stats"></span>
-                        <h3>{{ _('Track Demand') }}</h3>
-                        <p>{{ _('Support administrators with basic enrolment and course demand insights.') }}</p>
-                    </div>
                 </div>
             </section>
 


### PR DESCRIPTION
## Summary

This PR fixes the homepage layout regression caused by the feature cards being displayed between the hero section and the sign-in form.

## Changes

- Removed the redundant `Plan Timetables` and `Track Demand` feature cards from `templates/index.html`.
- Restored the hero action spacing in `static/css/style.css`.
- Improved the visual balance of the sign-in homepage.

## Testing

- Ran the application locally.
- Checked that the sign-in homepage no longer shows the redundant feature cards.
- Confirmed that the sign-in form layout looks cleaner and is no longer pushed down awkwardly.
- Confirmed that the top navigation, language button, and dark mode toggle still display correctly.

Closes #78 