### PR TITLE
feat: lock enrollment after confirmation and add change request flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import json
 import os
+from datetime import datetime
 from functools import wraps
 
 from flask import Flask, flash, redirect, render_template, request, session, url_for
@@ -20,7 +21,6 @@ app = Flask(__name__)
 app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "temporary-development-secret-key")
 app.config["ADMIN_EMAILS"] = os.environ.get("ADMIN_EMAILS", "admin@example.com")
 
-# Basic SQLite database configuration.
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///course_planner.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
@@ -46,12 +46,35 @@ login_manager.login_message = "Please sign in to access this page."
 login_manager.login_message_category = "error"
 
 
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
 class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     full_name = db.Column(db.String(100), nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
     student_id = db.Column(db.String(30), unique=True, nullable=False)
     password_hash = db.Column(db.String(255), nullable=False)
+    # Enrollment fields added for degree/course locking
+    selected_degree = db.Column(db.String(120), nullable=True)
+    enrollment_status = db.Column(
+        db.String(20),
+        default="planning"
+        # Values: 'planning' | 'enrolled' | 'change_requested'
+    )
+
+
+class EnrollmentChangeRequest(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    requested_degree = db.Column(db.String(120), nullable=False)
+    requested_course_codes = db.Column(db.Text, nullable=False)  # JSON string
+    status = db.Column(db.String(20), default="pending")  # 'pending' | 'approved' | 'rejected'
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    reviewed_at = db.Column(db.DateTime, nullable=True)
+
+    user = db.relationship("User", backref="change_requests")
 
 
 class Course(db.Model):
@@ -73,6 +96,10 @@ class Selection(db.Model):
     course = db.relationship("Course", backref="selections")
 
 
+# ---------------------------------------------------------------------------
+# Seed
+# ---------------------------------------------------------------------------
+
 def seed_courses():
     if Course.query.first():
         return
@@ -93,12 +120,15 @@ def seed_courses():
             semester=item["semester"],
             degree=item["degree"],
         )
-
         courses.append(course)
 
     db.session.add_all(courses)
     db.session.commit()
 
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
 
 @login_manager.user_loader
 def load_user(user_id):
@@ -111,7 +141,6 @@ def is_admin_user(user):
         for email in app.config["ADMIN_EMAILS"].split(",")
         if email.strip()
     }
-
     return user.is_authenticated and user.email.lower() in admin_emails
 
 
@@ -122,9 +151,7 @@ def admin_required(view_function):
         if not is_admin_user(current_user):
             flash(gettext("You do not have permission to access the admin dashboard."), "error")
             return redirect(url_for("homepage"))
-
         return view_function(*args, **kwargs)
-
     return wrapped_view
 
 
@@ -134,9 +161,7 @@ def student_required(view_function):
     def wrapped_view(*args, **kwargs):
         if is_admin_user(current_user):
             return redirect(url_for("admin_dashboard"))
-
         return view_function(*args, **kwargs)
-
     return wrapped_view
 
 
@@ -147,13 +172,20 @@ def inject_admin_status():
     }
 
 
+# ---------------------------------------------------------------------------
+# Language
+# ---------------------------------------------------------------------------
+
 @app.route("/set-language/<language>")
 def set_language(language):
     if language in app.config["LANGUAGES"]:
         session["language"] = language
-
     return redirect(request.referrer or url_for("index"))
 
+
+# ---------------------------------------------------------------------------
+# Auth routes
+# ---------------------------------------------------------------------------
 
 @app.route("/", methods=["GET", "POST"])
 def index():
@@ -269,6 +301,10 @@ def signup():
     return render_template("signup.html")
 
 
+# ---------------------------------------------------------------------------
+# Student page routes
+# ---------------------------------------------------------------------------
+
 @app.route("/homepage.html")
 @student_required
 def homepage():
@@ -281,11 +317,20 @@ def course_selection():
     return render_template("course-selection.html", current_user=current_user)
 
 
+@app.route("/timetable.html")
+@student_required
+def timetable():
+    return render_template("timetable.html", current_user=current_user)
+
+
+# ---------------------------------------------------------------------------
+# Student API — courses
+# ---------------------------------------------------------------------------
+
 @app.route("/api/courses")
 @student_required
 def api_courses():
     courses = Course.query.all()
-
     return {
         "courses": [
             {
@@ -302,59 +347,165 @@ def api_courses():
     }
 
 
-@app.route("/api/save-selection", methods=["POST"])
-@student_required
-def save_selection():
-    data = request.get_json()
-    course_codes = data.get("courses", [])
-
-    Selection.query.filter_by(user_id=current_user.id).delete()
-
-    for course_code in course_codes:
-        course = Course.query.filter_by(code=course_code).first()
-
-        if course:
-            selection = Selection(
-                user_id=current_user.id,
-                course_id=course.id
-            )
-            db.session.add(selection)
-
-    db.session.commit()
-
-    return {"message": "Selections saved successfully"}
-
 @app.route("/api/selected-courses")
 @student_required
 def api_selected_courses():
     selections = Selection.query.filter_by(user_id=current_user.id).all()
 
-    selected_degree = ""
-
-    if selections:
+    # Prefer the locked degree on the User record; fall back to inferring from courses.
+    selected_degree = current_user.selected_degree or ""
+    if not selected_degree and selections:
         selected_degree = selections[0].course.degree
 
     return {
         "degree": selected_degree,
+        "enrollment_status": current_user.enrollment_status or "planning",
         "courses": [
             {
-                "code": selection.course.code,
-                "name": selection.course.name,
-                "credits": selection.course.credits,
-                "time": selection.course.time,
-                "semester": selection.course.semester,
-                "degree": selection.course.degree,
-                "stream": selection.course.degree,
+                "code": s.course.code,
+                "name": s.course.name,
+                "credits": s.course.credits,
+                "time": s.course.time,
+                "semester": s.course.semester,
+                "degree": s.course.degree,
+                "stream": s.course.degree,
             }
-            for selection in selections
-        ]
+            for s in selections
+        ],
     }
 
-@app.route("/timetable.html")
-@student_required
-def timetable():
-    return render_template("timetable.html", current_user=current_user)
 
+# ---------------------------------------------------------------------------
+# Student API — enrollment
+# ---------------------------------------------------------------------------
+
+@app.route("/api/save-selection", methods=["POST"])
+@student_required
+def save_selection():
+    """
+    Draft save: persists the student's current working selection while they are
+    still in 'planning' status.  Does NOT lock them into 'enrolled'.
+    Once enrolled (or a change request is pending) this endpoint is blocked.
+    """
+    if current_user.enrollment_status in ("enrolled", "change_requested"):
+        return {
+            "error": "Already enrolled. Submit a change request to make changes."
+        }, 403
+
+    data = request.get_json()
+    course_codes = data.get("courses", [])
+    degree = data.get("degree", "")
+
+    Selection.query.filter_by(user_id=current_user.id).delete()
+    for code in course_codes:
+        course = Course.query.filter_by(code=code).first()
+        if course:
+            db.session.add(Selection(user_id=current_user.id, course_id=course.id))
+
+    if degree:
+        current_user.selected_degree = degree
+
+    db.session.commit()
+    return {"message": "Selection saved."}
+
+
+@app.route("/api/confirm-enrollment", methods=["POST"])
+@student_required
+def confirm_enrollment():
+    """
+    Locks the student's current selection as their official enrollment.
+    After this they can only change via the change-request workflow.
+    """
+    if current_user.enrollment_status == "enrolled":
+        return {"error": "Already enrolled."}, 400
+
+    if current_user.enrollment_status == "change_requested":
+        return {"error": "A change request is already pending approval."}, 400
+
+    selections = Selection.query.filter_by(user_id=current_user.id).count()
+    if selections == 0:
+        return {"error": "Please select at least one course before confirming enrollment."}, 400
+
+    if not current_user.selected_degree:
+        return {"error": "Please select a degree before confirming enrollment."}, 400
+
+    current_user.enrollment_status = "enrolled"
+    db.session.commit()
+    return {"message": "Enrollment confirmed! Changes now require admin approval."}
+
+
+@app.route("/api/request-change", methods=["POST"])
+@student_required
+def request_change():
+    """
+    Submits a change request for an already-enrolled student.
+    The student's current enrollment is preserved until the admin approves.
+    """
+    if current_user.enrollment_status != "enrolled":
+        return {"error": "You must be enrolled before submitting a change request."}, 400
+
+    existing_pending = EnrollmentChangeRequest.query.filter_by(
+        user_id=current_user.id, status="pending"
+    ).first()
+    if existing_pending:
+        return {"error": "You already have a pending change request."}, 400
+
+    data = request.get_json()
+    requested_degree = data.get("degree", "")
+    requested_courses = data.get("courses", [])
+
+    if not requested_degree or not requested_courses:
+        return {"error": "Please include a degree and at least one course in your request."}, 400
+
+    change_req = EnrollmentChangeRequest(
+        user_id=current_user.id,
+        requested_degree=requested_degree,
+        requested_course_codes=json.dumps(requested_courses),
+    )
+    current_user.enrollment_status = "change_requested"
+    db.session.add(change_req)
+    db.session.commit()
+    return {"message": "Change request submitted. Awaiting admin approval."}
+
+
+# ---------------------------------------------------------------------------
+# Admin API — change request management
+# ---------------------------------------------------------------------------
+
+@app.route("/api/admin/approve-change/<int:request_id>", methods=["POST"])
+@admin_required
+def approve_change(request_id):
+    req = EnrollmentChangeRequest.query.get_or_404(request_id)
+    user = User.query.get(req.user_id)
+
+    Selection.query.filter_by(user_id=user.id).delete()
+    for code in json.loads(req.requested_course_codes):
+        course = Course.query.filter_by(code=code).first()
+        if course:
+            db.session.add(Selection(user_id=user.id, course_id=course.id))
+
+    user.selected_degree = req.requested_degree
+    user.enrollment_status = "enrolled"
+    req.status = "approved"
+    req.reviewed_at = datetime.utcnow()
+    db.session.commit()
+    return {"message": "Change approved and applied."}
+
+
+@app.route("/api/admin/reject-change/<int:request_id>", methods=["POST"])
+@admin_required
+def reject_change(request_id):
+    req = EnrollmentChangeRequest.query.get_or_404(request_id)
+    req.user.enrollment_status = "enrolled"  # revert to locked without changes
+    req.status = "rejected"
+    req.reviewed_at = datetime.utcnow()
+    db.session.commit()
+    return {"message": "Change request rejected."}
+
+
+# ---------------------------------------------------------------------------
+# Admin dashboard route
+# ---------------------------------------------------------------------------
 
 @app.route("/admin-dashboard.html")
 @admin_required
@@ -366,15 +517,14 @@ def admin_dashboard():
 
     recent_user_records = User.query.order_by(User.id.desc()).limit(5).all()
     recent_users = []
-
     for user in recent_user_records:
         selected_count = Selection.query.filter_by(user_id=user.id).count()
-
         recent_users.append({
             "full_name": user.full_name,
             "email": user.email,
             "student_id": user.student_id,
             "selected_count": selected_count,
+            "enrollment_status": user.enrollment_status or "planning",
             "status": "Active" if selected_count > 0 else "No selections",
         })
 
@@ -391,6 +541,24 @@ def admin_dashboard():
         .all()
     )
 
+    # Pending change requests for the new admin panel
+    pending_req_records = EnrollmentChangeRequest.query.filter_by(status="pending").all()
+    pending_change_count = len(pending_req_records)
+    pending_changes = []
+    for req in pending_req_records:
+        course_codes = json.loads(req.requested_course_codes)
+        pending_changes.append({
+            "id": req.id,
+            "student_name": req.user.full_name,
+            "student_id": req.user.student_id,
+            "email": req.user.email,
+            "current_degree": req.user.selected_degree or "N/A",
+            "requested_degree": req.requested_degree,
+            "course_count": len(course_codes),
+            "requested_courses": course_codes,
+            "created_at": req.created_at.strftime("%d %b %Y, %H:%M") if req.created_at else "N/A",
+        })
+
     return render_template(
         "admin-dashboard.html",
         current_user=current_user,
@@ -400,7 +568,14 @@ def admin_dashboard():
         timetables_created=timetables_created,
         recent_users=recent_users,
         popular_courses=popular_courses,
+        pending_changes=pending_changes,
+        pending_change_count=pending_change_count,
     )
+
+
+# ---------------------------------------------------------------------------
+# Misc routes
+# ---------------------------------------------------------------------------
 
 @app.route("/logout")
 @login_required

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2584,4 +2584,195 @@ body.dark-mode .app-header {
     cursor: not-allowed;
     border: none;
     opacity: 1;
+.enrollment-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 14px 18px;
+    border-radius: 8px;
+    margin-bottom: 20px;
+    font-size: 0.92rem;
+    line-height: 1.5;
+    flex-wrap: wrap;
+}
+
+.enrollment-banner__icon {
+    font-size: 1.1rem;
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
+.enrollment-banner__actions {
+    display: flex;
+    gap: 8px;
+    margin-left: auto;
+    flex-shrink: 0;
+}
+
+/* Enrolled — locked, green */
+.enrollment-banner--enrolled {
+    background-color: #d4edda;
+    border: 1px solid #acd2b8;
+    color: #155724;
+}
+
+/* Change pending — amber */
+.enrollment-banner--pending {
+    background-color: #fff3cd;
+    border: 1px solid #ffc107;
+    color: #856404;
+}
+
+/* Drafting a change request — blue */
+.enrollment-banner--draft {
+    background-color: #d0e8ff;
+    border: 1px solid #90c4f9;
+    color: #0a4a7c;
+}
+
+/* Dark mode overrides */
+.dark-mode .enrollment-banner--enrolled {
+    background-color: #1a3a24;
+    border-color: #2d6a40;
+    color: #8dd4a0;
+}
+
+.dark-mode .enrollment-banner--pending {
+    background-color: #3a2f10;
+    border-color: #b38b00;
+    color: #ffd54f;
+}
+
+.dark-mode .enrollment-banner--draft {
+    background-color: #0d2a40;
+    border-color: #2870a0;
+    color: #7ac4f0;
+}
+
+/* ===================================================================   Sidebar — confirm & request-change buttons
+   ========================================================================== */
+
+.enrollment-action-btn {
+    width: 100%;
+    margin-top: 10px;
+    text-align: center;
+}
+
+/* ===================================================================   Pending change notice (inside sidebar)
+   ========================================================================== */
+
+.pending-change-notice {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 12px 14px;
+    border-radius: 8px;
+    background-color: #fff3cd;
+    border: 1px solid #ffc107;
+    color: #856404;
+    font-size: 0.88rem;
+    margin-top: 10px;
+    line-height: 1.45;
+}
+
+.pending-change-notice__icon {
+    font-size: 1rem;
+    flex-shrink: 0;
+    margin-top: 1px;
+}
+
+.dark-mode .pending-change-notice {
+    background-color: #3a2f10;
+    border-color: #b38b00;
+    color: #ffd54f;
+}
+
+/* ===================================================================   Admin dashboard — change request styles
+   ========================================================================== */
+
+/* Orange stat card when there are pending requests */
+.admin-stat-card--alert {
+    border-top: 3px solid #f0ad4e;
+}
+
+/* Badge shown next to the section title */
+.admin-pending-badge {
+    display: inline-block;
+    padding: 3px 10px;
+    border-radius: 12px;
+    background-color: #f0ad4e;
+    color: #fff;
+    font-size: 0.8rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+/* Alert value (e.g. pending count in summary card) */
+.admin-badge--alert {
+    color: #d9534f;
+}
+
+/* Degree value that is different from current */
+.admin-changed-value {
+    color: #e67e22;
+    font-weight: 600;
+}
+
+/* Action buttons column */
+.admin-action-cell {
+    white-space: nowrap;
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
+
+/* Empty state row */
+.admin-empty-row {
+    text-align: center;
+    color: #888;
+    font-style: italic;
+    padding: 20px 0;
+}
+
+/* Enrollment status badges in user table */
+.admin-status--enrolled {
+    background-color: #d4edda;
+    color: #155724;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.admin-status--pending {
+    background-color: #fff3cd;
+    color: #856404;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.admin-status--planning {
+    background-color: #e2e8f0;
+    color: #4a5568;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.dark-mode .admin-status--enrolled {
+    background-color: #1a3a24;
+    color: #8dd4a0;
+}
+
+.dark-mode .admin-status--pending {
+    background-color: #3a2f10;
+    color: #ffd54f;
+}
+
+.dark-mode .admin-status--planning {
+    background-color: #2d3748;
+    color: #a0aec0;
 }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -2,11 +2,13 @@ function t(text) {
     if (window.translations && window.translations[text]) {
         return window.translations[text];
     }
-
     return text;
 }
 
-// Checks the sign in form and shows a message to the user.
+// ---------------------------------------------------------------------------
+// Auth / password helpers (unchanged)
+// ---------------------------------------------------------------------------
+
 function loginUser() {
     let userEmail = document.getElementById("user-email").value;
     let userPassword = document.getElementById("user-password").value;
@@ -15,12 +17,10 @@ function loginUser() {
         alert(t("Please enter both your email address and password."));
         document.getElementById("signin-output").innerHTML =
             t("Sign in failed. Please complete all fields.");
-        console.log("Sign in failed: missing email or password.");
     } else {
         document.getElementById("signin-output").innerHTML =
             t("You have signed in successfully with email:") + " " + userEmail;
         alert(t("Sign in successful."));
-        console.log("User signed in with email: " + userEmail);
     }
 }
 
@@ -37,14 +37,11 @@ function resetPassword() {
         output.innerHTML = t("Please complete all fields.");
         return;
     }
-
     if (newPassword.length < 6) {
         output.innerHTML = t("Password must be at least 6 characters.");
         return;
     }
-
-    output.innerHTML =
-        t("Password reset successful for:") + " " + recoveryEmail;
+    output.innerHTML = t("Password reset successful for:") + " " + recoveryEmail;
 }
 
 let demoVerificationCode = "";
@@ -57,12 +54,9 @@ function sendVerificationCode() {
         output.innerHTML = t("Please enter your email address.");
         return;
     }
-
     localStorage.setItem("recoveryEmail", email);
     localStorage.setItem("verificationCode", "1234");
-
     output.innerHTML = t("Verification code sent. Redirecting...");
-
     setTimeout(function () {
         window.location.href = "/reset-password";
     }, 600);
@@ -72,27 +66,22 @@ function resetPasswordWithCode() {
     const verificationCode = getVerificationCodeFromBoxes();
     const newPassword = document.getElementById("new-password").value;
     const output = document.getElementById("reset-output");
-
     const savedCode = localStorage.getItem("verificationCode");
 
     if (verificationCode === "" || newPassword === "") {
         output.innerHTML = t("Please enter the verification code and new password.");
         return;
     }
-
     if (verificationCode !== savedCode) {
         output.innerHTML = t("Invalid verification code. Please try again.");
         return;
     }
-
     if (newPassword.length < 6) {
         output.innerHTML = t("Password must be at least 6 characters.");
         return;
     }
-
     output.innerHTML = t("Password reset successful! You can now sign in with your new password.");
     alert(t("Password reset successful! Please sign in again."));
-
     localStorage.removeItem("verificationCode");
     localStorage.removeItem("recoveryEmail");
 }
@@ -100,11 +89,7 @@ function resetPasswordWithCode() {
 function getVerificationCodeFromBoxes() {
     const inputs = document.querySelectorAll(".code-input");
     let code = "";
-
-    inputs.forEach(function (input) {
-        code += input.value;
-    });
-
+    inputs.forEach(function (input) { code += input.value; });
     return code;
 }
 
@@ -112,13 +97,8 @@ function updateResetFormState() {
     const code = getVerificationCodeFromBoxes();
     const passwordInput = document.getElementById("new-password");
     const resetButton = document.getElementById("reset-password-btn");
-
-    if (!passwordInput || !resetButton) {
-        return;
-    }
-
+    if (!passwordInput || !resetButton) return;
     const isCodeComplete = code.length === 4;
-
     passwordInput.disabled = !isCodeComplete;
     resetButton.disabled = !isCodeComplete;
 }
@@ -126,44 +106,28 @@ function updateResetFormState() {
 function handleCodeInput(event) {
     const input = event.target;
     const inputs = Array.from(document.querySelectorAll(".code-input"));
-
     input.value = input.value.replace(/\D/g, "");
-
     if (input.value.length === 1) {
         const currentIndex = inputs.indexOf(input);
         const nextInput = inputs[currentIndex + 1];
-
-        if (nextInput) {
-            nextInput.focus();
-        }
+        if (nextInput) nextInput.focus();
     }
-
     updateResetFormState();
 }
 
 function handleCodeBackspace(event) {
     const input = event.target;
     const inputs = Array.from(document.querySelectorAll(".code-input"));
-
     if (event.key === "Backspace" && input.value === "") {
         const currentIndex = inputs.indexOf(input);
         const previousInput = inputs[currentIndex - 1];
-
-        if (previousInput) {
-            previousInput.focus();
-        }
+        if (previousInput) previousInput.focus();
     }
-
     setTimeout(updateResetFormState, 0);
 }
 
-function goToSignUp() {
-    window.location.href = "/signup.html";
-}
-
-function goToSignIn() {
-    window.location.href = "/";
-}
+function goToSignUp() { window.location.href = "/signup.html"; }
+function goToSignIn() { window.location.href = "/"; }
 
 function registerUser() {
     let fullName = document.getElementById("full-name").value.trim();
@@ -173,30 +137,21 @@ function registerUser() {
     let confirmPassword = document.getElementById("confirm-password").value;
     let output = document.getElementById("signup-output");
 
-    if (
-        fullName === "" ||
-        signupEmail === "" ||
-        studentId === "" ||
-        signupPassword === "" ||
-        confirmPassword === ""
-    ) {
+    if (!fullName || !signupEmail || !studentId || !signupPassword || !confirmPassword) {
         alert(t("Please complete all registration fields."));
         output.innerHTML = t("Registration failed. Please complete all fields.");
         return;
     }
-
     if (signupPassword !== confirmPassword) {
         alert(t("Passwords do not match."));
         output.innerHTML = t("Registration failed. The passwords do not match.");
         return;
     }
-
     if (signupPassword.length < 6) {
         alert(t("Password must be at least 6 characters long."));
         output.innerHTML = t("Registration failed. Password must contain at least 6 characters.");
         return;
     }
-
     output.innerHTML =
         t("Account created successfully for") + " " + fullName + " " + t("with email:") + " " + signupEmail;
     alert(t("Registration successful."));
@@ -204,81 +159,99 @@ function registerUser() {
 
 function showDashboardMessage(message) {
     const dashboardOutput = document.getElementById("dashboard-output");
-
-    if (dashboardOutput) {
-        dashboardOutput.innerHTML = message;
-    }
-
-    console.log("Dashboard action clicked: " + message);
+    if (dashboardOutput) dashboardOutput.innerHTML = message;
 }
 
-const SELECTED_COURSES_STORAGE_KEY = "selectedCourses";
+// ---------------------------------------------------------------------------
+// Enrollment state
+// ---------------------------------------------------------------------------
 
+/**
+ * enrollmentStatus mirrors the server-side User.enrollment_status:
+ *   'planning'         — student is still freely selecting courses
+ *   'enrolled'         — selection is locked; changes need admin approval
+ *   'change_requested' — a change request is pending admin review
+ *
+ * isEditingChangeRequest is true only when the student has clicked
+ * "Request Change" and is drafting new course selections.  In this mode
+ * the UI is temporarily unlocked but changes go to /api/request-change,
+ * not /api/save-selection.
+ */
+let enrollmentStatus = "planning";
+let isEditingChangeRequest = false;
+
+// Snapshot of the enrolled selection so we can cancel a change draft.
+let enrolledCoursesSnapshot = [];
+let enrolledDegreeSnapshot = "";
+
+// ---------------------------------------------------------------------------
+// Course selection state
+// ---------------------------------------------------------------------------
+
+const SELECTED_COURSES_STORAGE_KEY = "selectedCourses";
 let selectedCourses = [];
 
 function loadSelectedCourses() {
-    const savedCourses = localStorage.getItem(SELECTED_COURSES_STORAGE_KEY);
-
-    if (!savedCourses) {
-        return [];
-    }
-
-    try {
-        return JSON.parse(savedCourses);
-    } catch (error) {
-        console.log("Selected courses could not be loaded:", error);
-        return [];
-    }
+    const saved = localStorage.getItem(SELECTED_COURSES_STORAGE_KEY);
+    if (!saved) return [];
+    try { return JSON.parse(saved); }
+    catch (e) { return []; }
 }
 
 function saveSelectedCourses() {
-    localStorage.setItem(
-        SELECTED_COURSES_STORAGE_KEY,
-        JSON.stringify(selectedCourses)
-    );
+    localStorage.setItem(SELECTED_COURSES_STORAGE_KEY, JSON.stringify(selectedCourses));
 }
 
+// ---------------------------------------------------------------------------
+// Backend sync — draft save (planning only)
+// ---------------------------------------------------------------------------
+
 function saveSelectedCoursesToBackend() {
-    const courseCodes = selectedCourses.map(function (course) {
-        return course.code;
-    });
+    // Never auto-save if locked and not in a change-request draft.
+    if ((enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
+        && !isEditingChangeRequest) {
+        return;
+    }
+
+    const degree = localStorage.getItem("selectedDegree") || "";
+    const courseCodes = selectedCourses.map(c => c.code);
 
     fetch("/api/save-selection", {
         method: "POST",
-        headers: {
-            "Content-Type": "application/json"
-        },
-        body: JSON.stringify({
-            courses: courseCodes
-        })
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ courses: courseCodes, degree: degree }),
     })
         .then(function (response) {
+            if (!response.ok) {
+                return response.json().then(function (d) {
+                    throw new Error(d.error || "Save failed.");
+                });
+            }
             return response.json();
         })
         .then(function (data) {
-            console.log(data.message);
+            console.log("Draft saved:", data.message);
         })
         .catch(function (error) {
-            console.log("Selected courses could not be saved:", error);
+            console.log("Save failed:", error);
         });
 }
 
+// ---------------------------------------------------------------------------
+// Backend sync — load selected courses + enrollment status
+// ---------------------------------------------------------------------------
+
 function loadSelectedCoursesFromBackend() {
     fetch("/api/selected-courses")
-        .then(function (response) {
-            return response.json();
-        })
+        .then(r => r.json())
         .then(function (data) {
+            enrollmentStatus = data.enrollment_status || "planning";
             selectedCourses = data.courses || [];
 
-            localStorage.setItem(
-                SELECTED_COURSES_STORAGE_KEY,
-                JSON.stringify(selectedCourses)
-            );
+            localStorage.setItem(SELECTED_COURSES_STORAGE_KEY, JSON.stringify(selectedCourses));
 
             if (selectedCourses.length > 0 && data.degree) {
                 const studyLevel = getStudyLevelByDegree(data.degree);
-
                 localStorage.setItem("selectedDegree", data.degree);
                 localStorage.setItem("selectedStudyLevel", studyLevel);
 
@@ -288,7 +261,6 @@ function loadSelectedCoursesFromBackend() {
                 if (studyLevelSelect && degreeSelect) {
                     studyLevelSelect.value = studyLevel;
                     updateDegreeOptions(false);
-
                     degreeSelect.value = data.degree;
                     selectDegree(false);
                 }
@@ -301,25 +273,32 @@ function loadSelectedCoursesFromBackend() {
             displaySelectedCourses();
             loadDashboardStats();
             loadTimetablePage();
+
+            // Lock the UI if the student is already enrolled or has a pending request.
+            if (enrollmentStatus !== "planning") {
+                lockEnrollmentUI(enrollmentStatus);
+            } else {
+                // Make sure the confirm button is visible in planning mode.
+                const confirmBtn = document.getElementById("confirm-enrollment-btn");
+                if (confirmBtn) confirmBtn.style.display = "block";
+            }
         })
         .catch(function (error) {
-            console.log("Selected courses could not be loaded from backend:", error);
+            console.log("Could not load selected courses:", error);
         });
 }
 
+// ---------------------------------------------------------------------------
+// Load course catalogue
+// ---------------------------------------------------------------------------
+
 function loadCoursesFromBackend() {
     fetch("/api/courses")
-        .then(function (response) {
-            return response.json();
-        })
+        .then(r => r.json())
         .then(function (data) {
             courseOptions = {};
-
             data.courses.forEach(function (course) {
-                if (!courseOptions[course.degree]) {
-                    courseOptions[course.degree] = [];
-                }
-
+                if (!courseOptions[course.degree]) courseOptions[course.degree] = [];
                 courseOptions[course.degree].push({
                     code: course.code,
                     name: course.name,
@@ -327,16 +306,17 @@ function loadCoursesFromBackend() {
                     time: course.time,
                     stream: course.degree,
                     degree: course.degree,
-                    semester: course.semester
+                    semester: course.semester,
                 });
             });
-
             restoreCourseSelectionForm();
         })
-        .catch(function (error) {
-            console.log("Courses could not be loaded from backend:", error);
-        });
+        .catch(err => console.log("Courses could not be loaded:", err));
 }
+
+// ---------------------------------------------------------------------------
+// Degree / study-level data
+// ---------------------------------------------------------------------------
 
 let courseOptions = {};
 
@@ -346,46 +326,284 @@ const degreeOptions = {
         "Bachelor of Commerce",
         "Bachelor of Science",
         "Bachelor of Biomedical Science",
-        "Bachelor of Engineering"
+        "Bachelor of Engineering",
     ],
     master: [
         "Master of Information Technology",
         "Master of Data Science",
         "Master of Business Analytics",
         "Master of Professional Engineering",
-        "Master of Studies"
+        "Master of Studies",
     ],
     diploma: [
         "Graduate Diploma in Health Professions Education",
         "Graduate Diploma in Infectious Diseases",
         "Graduate Diploma in Environmental Science",
         "Graduate Diploma in Business",
-        "Graduate Diploma in Education"
-    ]
+        "Graduate Diploma in Education",
+    ],
 };
 
 function getStudyLevelByDegree(degreeName) {
     for (const level in degreeOptions) {
-        if (degreeOptions[level].includes(degreeName)) {
-            return level;
-        }
+        if (degreeOptions[level].includes(degreeName)) return level;
     }
-
     return "";
 }
 
+// ---------------------------------------------------------------------------
+// Enrollment UI lock / unlock
+// ---------------------------------------------------------------------------
 
-// Updates the degree dropdown after the user selects a study level.
+/**
+ * Locks all editable UI elements and shows the appropriate status banner.
+ * Called when enrollmentStatus is 'enrolled' or 'change_requested'.
+ */
+function lockEnrollmentUI(status) {
+    // Disable degree / study-level selects
+    const studyLevelSelect = document.getElementById("study-level-select");
+    const degreeSelect = document.getElementById("degree-select");
+    if (studyLevelSelect) studyLevelSelect.disabled = true;
+    if (degreeSelect) degreeSelect.disabled = true;
+
+    // Disable all Add buttons in the course table
+    document.querySelectorAll("[data-course-code]").forEach(function (btn) {
+        btn.disabled = true;
+        btn.textContent = "Added";
+        btn.classList.add("added-course-btn");
+    });
+
+    // Show enrollment status banner
+    const banner = document.getElementById("enrollment-status-banner");
+    if (banner) {
+        banner.style.display = "flex";
+        if (status === "enrolled") {
+            banner.className = "enrollment-banner enrollment-banner--enrolled";
+            banner.innerHTML =
+                '<span class="enrollment-banner__icon">✓</span>' +
+                '<span>' + t("You are enrolled. To make changes to your degree or courses, use the Request Change button below.") + '</span>';
+        } else if (status === "change_requested") {
+            banner.className = "enrollment-banner enrollment-banner--pending";
+            banner.innerHTML =
+                '<span class="enrollment-banner__icon">⏳</span>' +
+                '<span>' + t("Your change request is pending admin approval. Your current enrollment remains active.") + '</span>';
+        }
+    }
+
+    // Toggle sidebar action buttons
+    const confirmBtn = document.getElementById("confirm-enrollment-btn");
+    const requestChangeBtn = document.getElementById("request-change-btn");
+    const pendingNotice = document.getElementById("pending-change-notice");
+
+    if (confirmBtn) confirmBtn.style.display = "none";
+
+    if (status === "enrolled") {
+        if (requestChangeBtn) requestChangeBtn.style.display = "block";
+        if (pendingNotice) pendingNotice.style.display = "none";
+    } else if (status === "change_requested") {
+        if (requestChangeBtn) requestChangeBtn.style.display = "none";
+        if (pendingNotice) pendingNotice.style.display = "block";
+    }
+
+    // Re-render selected courses (no Remove buttons while locked)
+    displaySelectedCourses();
+}
+
+/**
+ * Unlocks the UI for drafting a change request.
+ * Only the course list / degree selects are re-enabled — the state is
+ * kept separate from the confirmed enrollment until the request is submitted.
+ */
+function unlockForChangeRequest() {
+    const studyLevelSelect = document.getElementById("study-level-select");
+    const degreeSelect = document.getElementById("degree-select");
+    if (studyLevelSelect) studyLevelSelect.disabled = false;
+    if (degreeSelect) degreeSelect.disabled = false;
+
+    // Re-enable Add buttons for the currently displayed degree
+    const currentDegree = localStorage.getItem("selectedDegree") || "";
+    if (currentDegree) displayAvailableCourses(currentDegree);
+
+    displaySelectedCourses(); // re-renders with Remove buttons
+}
+
+// ---------------------------------------------------------------------------
+// Confirm enrollment
+// ---------------------------------------------------------------------------
+
+function confirmEnrollment() {
+    if (selectedCourses.length === 0) {
+        alert(t("Please select at least one course before confirming enrollment."));
+        return;
+    }
+    const degree = localStorage.getItem("selectedDegree") || "";
+    if (!degree) {
+        alert(t("Please select a degree before confirming enrollment."));
+        return;
+    }
+    if (!confirm(t("Confirm your enrollment? After confirming, any changes will require admin approval."))) {
+        return;
+    }
+
+    // Save the current draft first, then confirm.
+    const courseCodes = selectedCourses.map(c => c.code);
+    fetch("/api/save-selection", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ courses: courseCodes, degree: degree }),
+    })
+        .then(r => r.json())
+        .then(function () {
+            return fetch("/api/confirm-enrollment", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+            });
+        })
+        .then(r => r.json())
+        .then(function (data) {
+            if (data.error) {
+                alert(data.error);
+                return;
+            }
+            enrollmentStatus = "enrolled";
+            lockEnrollmentUI("enrolled");
+            alert(t("Enrollment confirmed successfully!"));
+        })
+        .catch(function (err) {
+            console.log("Confirm enrollment failed:", err);
+            alert(t("Something went wrong. Please try again."));
+        });
+}
+
+// ---------------------------------------------------------------------------
+// Change request flow
+// ---------------------------------------------------------------------------
+
+/**
+ * Enters "draft change request" mode:
+ *  - Saves a snapshot of the current enrolled selection.
+ *  - Unlocks the UI for editing.
+ *  - Swaps the status banner to a draft-mode banner with Submit / Cancel.
+ */
+function requestChange() {
+    // Snapshot the enrolled state so Cancel can restore it.
+    enrolledCoursesSnapshot = JSON.parse(JSON.stringify(selectedCourses));
+    enrolledDegreeSnapshot = localStorage.getItem("selectedDegree") || "";
+    isEditingChangeRequest = true;
+
+    unlockForChangeRequest();
+
+    // Update the banner to draft mode
+    const banner = document.getElementById("enrollment-status-banner");
+    if (banner) {
+        banner.style.display = "flex";
+        banner.className = "enrollment-banner enrollment-banner--draft";
+        banner.innerHTML =
+            '<span class="enrollment-banner__icon">✏️</span>' +
+            '<span>' + t("You are drafting a change request. Your current enrollment stays active until an admin approves your request.") + '</span>' +
+            '<div class="enrollment-banner__actions">' +
+            '  <button class="btn dashboard-btn-primary" onclick="submitChangeRequest()">' + t("Submit Request") + '</button>' +
+            '  <button class="btn dashboard-btn-secondary" onclick="cancelChangeRequest()">' + t("Cancel") + '</button>' +
+            '</div>';
+    }
+
+    // Hide the Request Change button while drafting
+    const requestChangeBtn = document.getElementById("request-change-btn");
+    if (requestChangeBtn) requestChangeBtn.style.display = "none";
+
+    const msg = document.getElementById("course-message");
+    if (msg) {
+        msg.textContent = t("Select the courses you would like in your updated enrollment, then click Submit Request.");
+    }
+}
+
+/**
+ * Cancels a change request draft and restores the enrolled state.
+ */
+function cancelChangeRequest() {
+    isEditingChangeRequest = false;
+    selectedCourses = enrolledCoursesSnapshot;
+    localStorage.setItem(SELECTED_COURSES_STORAGE_KEY, JSON.stringify(selectedCourses));
+    localStorage.setItem("selectedDegree", enrolledDegreeSnapshot);
+
+    const studyLevel = getStudyLevelByDegree(enrolledDegreeSnapshot);
+    localStorage.setItem("selectedStudyLevel", studyLevel);
+
+    const studyLevelSelect = document.getElementById("study-level-select");
+    const degreeSelect = document.getElementById("degree-select");
+    if (studyLevelSelect && degreeSelect) {
+        studyLevelSelect.value = studyLevel;
+        updateDegreeOptions(false);
+        degreeSelect.value = enrolledDegreeSnapshot;
+        selectDegree(false);
+    }
+
+    enrollmentStatus = "enrolled";
+    lockEnrollmentUI("enrolled");
+}
+
+/**
+ * Submits the drafted changes as an EnrollmentChangeRequest.
+ * The student's live enrollment is not changed until the admin approves.
+ */
+function submitChangeRequest() {
+    if (selectedCourses.length === 0) {
+        alert(t("Please select at least one course for your change request."));
+        return;
+    }
+    const degree = localStorage.getItem("selectedDegree") || "";
+    if (!degree) {
+        alert(t("Please select a degree for your change request."));
+        return;
+    }
+
+    fetch("/api/request-change", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            degree: degree,
+            courses: selectedCourses.map(c => c.code),
+        }),
+    })
+        .then(r => r.json())
+        .then(function (data) {
+            if (data.error) {
+                alert(data.error);
+                return;
+            }
+            // Revert to enrolled snapshot — the change is only pending
+            isEditingChangeRequest = false;
+            selectedCourses = enrolledCoursesSnapshot;
+            localStorage.setItem(SELECTED_COURSES_STORAGE_KEY, JSON.stringify(selectedCourses));
+
+            enrollmentStatus = "change_requested";
+            lockEnrollmentUI("change_requested");
+            alert(t("Change request submitted! An admin will review your request."));
+        })
+        .catch(function (err) {
+            console.log("Submit change request failed:", err);
+            alert(t("Something went wrong. Please try again."));
+        });
+}
+
+// ---------------------------------------------------------------------------
+// Degree / course UI
+// ---------------------------------------------------------------------------
+
 function updateDegreeOptions(shouldResetCourses = true) {
+    // Locked while enrolled and not in a change-request draft
+    if ((enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
+        && !isEditingChangeRequest) {
+        return;
+    }
+
     const studyLevelSelect = document.getElementById("study-level-select");
     const degreeSelect = document.getElementById("degree-select");
     const courseMessage = document.getElementById("course-message");
     const degreeSummary = document.getElementById("degree-summary");
     const studyLevelSummary = document.getElementById("study-level-summary");
 
-    if (!studyLevelSelect || !degreeSelect) {
-        return;
-    }
+    if (!studyLevelSelect || !degreeSelect) return;
 
     const selectedLevel = studyLevelSelect.value;
     const selectedLevelText = studyLevelSelect.options[studyLevelSelect.selectedIndex].text;
@@ -401,29 +619,18 @@ function updateDegreeOptions(shouldResetCourses = true) {
     }
 
     displayAvailableCourses("");
-
     degreeSelect.innerHTML = "";
 
     if (!selectedLevel) {
         degreeSelect.disabled = true;
-
         const defaultOption = document.createElement("option");
         defaultOption.value = "";
         defaultOption.textContent = t("-- Select a study level first --");
         degreeSelect.appendChild(defaultOption);
 
-        if (courseMessage) {
-            courseMessage.textContent = t("Please select a study level, then choose a degree before adding courses.");
-        }
-
-        if (degreeSummary) {
-            degreeSummary.textContent = t("Not selected");
-        }
-
-        if (studyLevelSummary) {
-            studyLevelSummary.textContent = t("Not selected");
-        }
-
+        if (courseMessage) courseMessage.textContent = t("Please select a study level, then choose a degree before adding courses.");
+        if (degreeSummary) degreeSummary.textContent = t("Not selected");
+        if (studyLevelSummary) studyLevelSummary.textContent = t("Not selected");
         return;
     }
 
@@ -441,57 +648,41 @@ function updateDegreeOptions(shouldResetCourses = true) {
         degreeSelect.appendChild(option);
     });
 
-    if (courseMessage) {
-        courseMessage.textContent =
-            t("Now select a degree from the available") + " " + selectedLevelText + " " + t("options.");
-    }
-
-    if (degreeSummary) {
-        degreeSummary.textContent = t("Not selected");
-    }
-
-    if (studyLevelSummary) {
-        studyLevelSummary.textContent = selectedLevelText;
-    }
+    if (courseMessage) courseMessage.textContent = t("Now select a degree from the available") + " " + selectedLevelText + " " + t("options.");
+    if (degreeSummary) degreeSummary.textContent = t("Not selected");
+    if (studyLevelSummary) studyLevelSummary.textContent = selectedLevelText;
 }
 
-// Updates the selected degree summary after the user selects a degree.
 function selectDegree(shouldResetCourses = true) {
+    // Locked while enrolled and not in a change-request draft
+    if ((enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
+        && !isEditingChangeRequest) {
+        return;
+    }
+
     const degreeSelect = document.getElementById("degree-select");
     const courseMessage = document.getElementById("course-message");
     const degreeSummary = document.getElementById("degree-summary");
 
-    if (!degreeSelect) {
-        return;
-    }
+    if (!degreeSelect) return;
 
     const selectedDegree = degreeSelect.value;
 
     if (!selectedDegree) {
         selectedCourses = [];
         saveSelectedCourses();
-
         localStorage.removeItem("selectedDegree");
         localStorage.setItem("timetableGenerated", "false");
-
         displaySelectedCourses();
         loadDashboardStats();
-
-        if (courseMessage) {
-            courseMessage.textContent = t("Please choose a degree before adding courses.");
-        }
-
-        if (degreeSummary) {
-            degreeSummary.textContent = t("Not selected");
-        }
-
+        if (courseMessage) courseMessage.textContent = t("Please choose a degree before adding courses.");
+        if (degreeSummary) degreeSummary.textContent = t("Not selected");
         displayAvailableCourses("");
         return;
     }
 
     localStorage.setItem("selectedDegree", selectedDegree);
 
-    // Reset selected courses whenever the degree changes.
     if (shouldResetCourses) {
         selectedCourses = [];
         saveSelectedCourses();
@@ -500,24 +691,15 @@ function selectDegree(shouldResetCourses = true) {
         loadDashboardStats();
     }
 
-    if (courseMessage) {
-        courseMessage.textContent =
-            t(selectedDegree) + " " + t("selected. You can now add courses to your study plan.");
-    }
-
-    if (degreeSummary) {
-        degreeSummary.textContent = t(selectedDegree);
-    }
+    if (courseMessage) courseMessage.textContent = t(selectedDegree) + " " + t("selected. You can now add courses to your study plan.");
+    if (degreeSummary) degreeSummary.textContent = t(selectedDegree);
 
     displayAvailableCourses(selectedDegree);
 }
 
 function displayAvailableCourses(degreeName) {
     const availableCoursesBox = document.getElementById("available-courses");
-
-    if (!availableCoursesBox) {
-        return;
-    }
+    if (!availableCoursesBox) return;
 
     const courses = courseOptions[degreeName];
 
@@ -525,60 +707,55 @@ function displayAvailableCourses(degreeName) {
         availableCoursesBox.innerHTML = `
             <div class="empty-course-state">
                 <p>${t("Please select a study level and degree to view available courses.")}</p>
-            </div>
-        `;
+            </div>`;
         return;
     }
 
+    const isLocked = (enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
+        && !isEditingChangeRequest;
+
     availableCoursesBox.innerHTML = `
-    <div class="course-table">
-        <div class="course-table-header">
-            <span>Code</span>
-            <span>Course</span>
-            <span>Time</span>
-            <span>Credits</span>
-            <span></span>
-        </div>
-
-        ${courses.map(course => `
-            <div class="course-table-row"
-                data-search="${course.code.toLowerCase()} ${course.name.toLowerCase()}"
-                data-semester="${course.semester}">
-
-                <span class="course-code">${course.code}</span>
-
-                <span class="course-table-name">${course.name}</span>
-
-                <span>${course.time}</span>
-
-                <span>${course.credits} credits</span>
-
-                <button type="button" class="btn dashboard-btn-primary"
-                    data-course-code="${course.code}"
-                    onclick="addCourse(event,'${course.code}', '${course.name}', ${course.credits}, '${course.time}', '${course.degree}', '${course.semester}')">
-                    Add
-                </button>
+        <div class="course-table">
+            <div class="course-table-header">
+                <span>Code</span>
+                <span>Course</span>
+                <span>Time</span>
+                <span>Credits</span>
+                <span></span>
             </div>
-        `).join("")}
-    </div>
-`;
+            ${courses.map(course => `
+                <div class="course-table-row"
+                    data-search="${course.code.toLowerCase()} ${course.name.toLowerCase()}"
+                    data-semester="${course.semester}">
+                    <span class="course-code">${course.code}</span>
+                    <span class="course-table-name">${course.name}</span>
+                    <span>${course.time}</span>
+                    <span>${course.credits} credits</span>
+                    <button type="button"
+                        class="btn dashboard-btn-primary${isLocked ? ' added-course-btn' : ''}"
+                        data-course-code="${course.code}"
+                        ${isLocked ? 'disabled' : ''}
+                        onclick="addCourse(event,'${course.code}','${course.name}',${course.credits},'${course.time}','${course.degree}','${course.semester}')">
+                        Add
+                    </button>
+                </div>
+            `).join("")}
+        </div>`;
 
     filterCourses();
     updateAddButtonStates();
 }
 
 function updateAddButtonStates() {
-    const addButtons = document.querySelectorAll("[data-course-code]");
+    const isLocked = (enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
+        && !isEditingChangeRequest;
 
-    addButtons.forEach(function (button) {
+    document.querySelectorAll("[data-course-code]").forEach(function (button) {
         const courseCode = button.dataset.courseCode;
+        const isSelected = selectedCourses.some(c => c.code === courseCode);
 
-        const isSelected = selectedCourses.some(function (course) {
-            return course.code === courseCode;
-        });
-
-        if (isSelected) {
-            button.textContent = "Added";
+        if (isLocked || isSelected) {
+            button.textContent = isSelected ? "Added" : "Add";
             button.disabled = true;
             button.classList.add("added-course-btn");
         } else {
@@ -590,62 +767,51 @@ function updateAddButtonStates() {
 }
 
 function addCourse(event, code, name, credits, time, degree, semester) {
+    // Block if locked and not in a change-request draft
+    if ((enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
+        && !isEditingChangeRequest) {
+        alert(t("You are enrolled. Use the Request Change button to modify your selection."));
+        return;
+    }
+
     const degreeSelect = document.getElementById("degree-select");
     const message = document.getElementById("course-message");
 
     if (degreeSelect && degreeSelect.value === "") {
-        if (message) {
-            message.innerHTML = t("Please select a degree first.");
-        }
+        if (message) message.innerHTML = t("Please select a degree first.");
         return;
     }
 
-    const existingSemester = selectedCourses.length > 0
-        ? selectedCourses[0].semester
-        : null;
-
+    const existingSemester = selectedCourses.length > 0 ? selectedCourses[0].semester : null;
     if (existingSemester && existingSemester !== semester) {
         alert(t("Semester conflict detected. Please select courses from the same semester."));
         return;
     }
 
-    const timeConflict = selectedCourses.some(function (course) {
-        return course.time === time;
-    });
-
+    const timeConflict = selectedCourses.some(c => c.time === time);
     if (timeConflict) {
         alert(t("Time conflict detected. This course overlaps with another selected course."));
         return;
     }
 
-    const exists = selectedCourses.some(course => course.code === code);
-
+    const exists = selectedCourses.some(c => c.code === code);
     if (exists) {
-        if (message) {
-            message.innerHTML = code + " " + t("has already been added.");
-        }
+        if (message) message.innerHTML = code + " " + t("has already been added.");
         return;
     }
 
-    selectedCourses.push({
-        code: code,
-        name: name,
-        credits: credits,
-        time: time,
-        stream: degree,
-        degree: degree,
-        semester: semester
-    });
-
+    selectedCourses.push({ code, name, credits, time, stream: degree, degree, semester });
     localStorage.setItem("selectedCourses", JSON.stringify(selectedCourses));
 
-    if (message) {
-        message.innerHTML = code + " " + t("added successfully.");
-    }
+    if (message) message.innerHTML = code + " " + t("added successfully.");
 
     displaySelectedCourses();
     updateAddButtonStates();
-    saveSelectedCoursesToBackend();
+
+    // Only auto-save to backend during planning mode (not during a change-request draft)
+    if (!isEditingChangeRequest) {
+        saveSelectedCoursesToBackend();
+    }
 }
 
 function displaySelectedCourses() {
@@ -654,63 +820,50 @@ function displaySelectedCourses() {
     const creditSummary = document.getElementById("credit-summary");
     const courseCountSummary = document.getElementById("course-count-summary");
 
-    if (!selectedBox || !creditOutput) {
-        return;
-    }
+    if (!selectedBox || !creditOutput) return;
+
+    // Remove buttons are only shown while planning or in a change-request draft
+    const canRemove = enrollmentStatus === "planning" || isEditingChangeRequest;
 
     if (selectedCourses.length === 0) {
         selectedBox.innerHTML = `<p>${t("No courses selected yet.")}</p>`;
         creditOutput.innerHTML = "0";
-
-        if (creditSummary) {
-            creditSummary.textContent = "0";
-        }
-
-        if (courseCountSummary) {
-            courseCountSummary.textContent = "0";
-        }
-
+        if (creditSummary) creditSummary.textContent = "0";
+        if (courseCountSummary) courseCountSummary.textContent = "0";
         return;
     }
 
     let totalCredits = 0;
-
     selectedBox.innerHTML = selectedCourses.map(course => {
         totalCredits += course.credits;
-
         return `
-        <div class="selected-course-item">
-            <div class="selected-course-info">
-                <strong>${course.code}</strong>
-                <span>${t(course.name)} · ${course.credits} ${t("credit points")}</span>
-            </div>
-
-            <button
-                class="remove-course-btn"
-                onclick="removeCourse('${course.code}')"
-            >
-                ${t("Remove")}
-            </button>
-        </div>
-`;
+            <div class="selected-course-item">
+                <div class="selected-course-info">
+                    <strong>${course.code}</strong>
+                    <span>${t(course.name)} · ${course.credits} ${t("credit points")}</span>
+                </div>
+                ${canRemove
+                    ? `<button class="remove-course-btn" onclick="removeCourse('${course.code}')">${t("Remove")}</button>`
+                    : ""}
+            </div>`;
     }).join("");
 
     creditOutput.innerHTML = totalCredits;
-
-    if (creditSummary) {
-        creditSummary.textContent = totalCredits;
-    }
-
-    if (courseCountSummary) {
-        courseCountSummary.textContent = selectedCourses.length;
-    }
+    if (creditSummary) creditSummary.textContent = totalCredits;
+    if (courseCountSummary) courseCountSummary.textContent = selectedCourses.length;
 }
 
 function removeCourse(code) {
+    // Block if locked
+    if ((enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
+        && !isEditingChangeRequest) {
+        return;
+    }
+
     const currentDegree = localStorage.getItem("selectedDegree");
     const message = document.getElementById("course-message");
 
-    selectedCourses = selectedCourses.filter(course => course.code !== code);
+    selectedCourses = selectedCourses.filter(c => c.code !== code);
     saveSelectedCourses();
 
     if (selectedCourses.length === 0) {
@@ -720,15 +873,13 @@ function removeCourse(code) {
     displaySelectedCourses();
     loadTimetablePage();
     loadDashboardStats();
-    saveSelectedCoursesToBackend();
 
-    if (currentDegree) {
-        displayAvailableCourses(currentDegree);
+    if (!isEditingChangeRequest) {
+        saveSelectedCoursesToBackend();
     }
 
-    if (message) {
-        message.innerHTML = code + " " + t("removed successfully.");
-    }
+    if (currentDegree) displayAvailableCourses(currentDegree);
+    if (message) message.innerHTML = code + " " + t("removed successfully.");
 }
 
 function filterCourses() {
@@ -736,34 +887,24 @@ function filterCourses() {
     const semesterFilter = document.getElementById("semester-filter");
     const courseCards = document.querySelectorAll(".course-table-row");
 
-    if (!searchInput || !semesterFilter) {
-        return;
-    }
+    if (!searchInput || !semesterFilter) return;
 
     const searchTerm = searchInput.value.trim().toLowerCase();
     const selectedSemester = semesterFilter.value;
 
     courseCards.forEach(function (card) {
-        const searchData = card.dataset.search;
-        const semesterData = card.dataset.semester;
-
-        const matchesSearch = searchTerm === "" || searchData.includes(searchTerm);
-
-        const matchesSemester =
-            selectedSemester === "all" ||
-            semesterData === selectedSemester;
-
-        if (matchesSearch && matchesSemester) {
-            card.style.display = "grid";
-        } else {
-            card.style.display = "none";
-        }
+        const matchesSearch = searchTerm === "" || card.dataset.search.includes(searchTerm);
+        const matchesSemester = selectedSemester === "all" || card.dataset.semester === selectedSemester;
+        card.style.display = (matchesSearch && matchesSemester) ? "grid" : "none";
     });
 }
 
+// ---------------------------------------------------------------------------
+// Theme
+// ---------------------------------------------------------------------------
+
 function applySavedTheme() {
     const savedTheme = localStorage.getItem("coursePlannerTheme");
-
     if (savedTheme === "dark") {
         document.body.classList.add("dark-mode");
         updateThemeToggleLabel("Light");
@@ -775,7 +916,6 @@ function applySavedTheme() {
 
 function toggleDarkMode() {
     document.body.classList.toggle("dark-mode");
-
     if (document.body.classList.contains("dark-mode")) {
         localStorage.setItem("coursePlannerTheme", "dark");
         updateThemeToggleLabel("Light");
@@ -787,23 +927,17 @@ function toggleDarkMode() {
 
 function updateThemeToggleLabel(labelText) {
     const themeButtons = document.querySelectorAll(".theme-toggle");
-
     themeButtons.forEach(function (button) {
         const label = button.querySelector(".theme-toggle-label");
-
-        if (label) {
-            label.textContent = t(labelText);
-        }
-
-        if (labelText === "Light") {
-            button.setAttribute("aria-pressed", "true");
-        } else {
-            button.setAttribute("aria-pressed", "false");
-        }
+        if (label) label.textContent = t(labelText);
+        button.setAttribute("aria-pressed", labelText === "Light" ? "true" : "false");
     });
 }
 
-// The following functions are placeholders for the timetable generation, clearing, and sharing features.
+// ---------------------------------------------------------------------------
+// Timetable
+// ---------------------------------------------------------------------------
+
 function loadTimetablePage() {
     const savedCourses = JSON.parse(localStorage.getItem("selectedCourses")) || [];
     const courseList = document.getElementById("timetable-course-list");
@@ -812,63 +946,34 @@ function loadTimetablePage() {
     const courseCount = document.getElementById("timetable-course-count");
     const creditTotal = document.getElementById("timetable-credit-total");
 
-    if (!courseList) {
-        return;
-    }
+    if (!courseList) return;
 
     if (savedCourses.length === 0) {
         courseList.innerHTML = `<p>${t("No courses selected yet.")}</p>`;
-
-        if (status) {
-            status.innerHTML = t("Not generated");
-        }
-
-        if (output) {
-            output.innerHTML = t("Please select courses before generating a timetable.");
-        }
-
-        if (courseCount) {
-            courseCount.textContent = "0";
-        }
-
-        if (creditTotal) {
-            creditTotal.textContent = "0";
-        }
-
+        if (status) status.innerHTML = t("Not generated");
+        if (output) output.innerHTML = t("Please select courses before generating a timetable.");
+        if (courseCount) courseCount.textContent = "0";
+        if (creditTotal) creditTotal.textContent = "0";
         renderEmptyWeeklyCalendar();
         return;
     }
 
     let totalCredits = 0;
-
     courseList.innerHTML = savedCourses.map(function (course) {
         totalCredits += course.credits;
-
         return `
             <div class="timetable-course-item">
                 <strong>${course.code}</strong>
                 <span>${t(course.name)}</span>
                 <small>${course.time} · ${course.credits} ${t("credits")}</small>
-            </div>
-        `;
+            </div>`;
     }).join("");
 
-    if (status) {
-        status.innerHTML = t("Ready");
-    }
+    if (status) status.innerHTML = t("Ready");
+    if (courseCount) courseCount.innerHTML = savedCourses.length;
+    if (creditTotal) creditTotal.innerHTML = totalCredits;
 
-    if (courseCount) {
-        courseCount.innerHTML = savedCourses.length;
-    }
-
-    if (creditTotal) {
-        creditTotal.innerHTML = totalCredits;
-    }
-
-    const timetableGenerated =
-        localStorage.getItem("timetableGenerated");
-
-    if (timetableGenerated === "true") {
+    if (localStorage.getItem("timetableGenerated") === "true") {
         generateTimetable();
     } else {
         renderEmptyWeeklyCalendar();
@@ -877,28 +982,17 @@ function loadTimetablePage() {
 
 function renderEmptyWeeklyCalendar() {
     const calendar = document.getElementById("weekly-calendar");
-
-    if (!calendar) {
-        return;
-    }
+    if (!calendar) return;
 
     const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
     const times = ["09:00", "10:00", "11:00", "12:00", "13:00", "14:00", "15:00", "16:00"];
 
     let html = `<div class="calendar-time-header"></div>`;
-
-    days.forEach(function (day) {
-        html += `<div class="calendar-day-header">${t(day)}</div>`;
-    });
-
+    days.forEach(day => { html += `<div class="calendar-day-header">${t(day)}</div>`; });
     times.forEach(function (time) {
         html += `<div class="calendar-time">${time}</div>`;
-
-        days.forEach(function (day) {
-            html += `<div class="calendar-cell" data-day="${day}" data-time="${time}"></div>`;
-        });
+        days.forEach(day => { html += `<div class="calendar-cell" data-day="${day}" data-time="${time}"></div>`; });
     });
-
     calendar.innerHTML = html;
 }
 
@@ -908,266 +1002,178 @@ function generateTimetable() {
     const output = document.getElementById("timetable-output");
 
     if (savedCourses.length === 0) {
-        if (output) {
-            output.innerHTML = t("Please select courses before generating a timetable.");
-        }
+        if (output) output.innerHTML = t("Please select courses before generating a timetable.");
         return;
     }
 
-    const semesters = savedCourses.map(course => course.semester);
-    const uniqueSemesters = [...new Set(semesters)];
-
+    const uniqueSemesters = [...new Set(savedCourses.map(c => c.semester))];
     if (uniqueSemesters.length > 1) {
-        if (status) {
-            status.innerHTML = t("Conflict");
-        }
-
-        if (output) {
-            output.innerHTML = t("You selected courses from different semesters. Please choose courses from one semester before generating a timetable.");
-        }
-
+        if (status) status.innerHTML = t("Conflict");
+        if (output) output.innerHTML = t("You selected courses from different semesters. Please choose courses from one semester before generating a timetable.");
         renderEmptyWeeklyCalendar();
         return;
     }
 
     renderEmptyWeeklyCalendar();
-
     savedCourses.forEach(function (course) {
-        const day = getCourseDay(course.time);
-        const startTime = getCourseStartTime(course.time);
-
         const cell = document.querySelector(
-            `.calendar-cell[data-day="${day}"][data-time="${startTime}"]`
+            `.calendar-cell[data-day="${getCourseDay(course.time)}"][data-time="${getCourseStartTime(course.time)}"]`
         );
-
         if (cell) {
             cell.classList.add("course-block");
-            cell.innerHTML = `
-                <strong>${course.code}</strong>
-                <span>${t(course.name)}</span>
-                <small>${course.time}</small>
-            `;
+            cell.innerHTML = `<strong>${course.code}</strong><span>${t(course.name)}</span><small>${course.time}</small>`;
         }
     });
 
-    if (status) {
-        status.innerHTML = t("Generated");
-    }
-
-    if (output) {
-        output.innerHTML = t("The weekly timetable has been generated successfully.");
-    }
-
+    if (status) status.innerHTML = t("Generated");
+    if (output) output.innerHTML = t("The weekly timetable has been generated successfully.");
     localStorage.setItem("timetableGenerated", "true");
 }
 
 function clearTimetable() {
     renderEmptyWeeklyCalendar();
-
     const status = document.getElementById("timetable-status");
     const output = document.getElementById("timetable-output");
-
-    if (status) {
-        status.innerHTML = t("Not generated");
-    }
-
-    if (output) {
-        output.innerHTML = t("The timetable has been cleared.");
-    }
-
+    if (status) status.innerHTML = t("Not generated");
+    if (output) output.innerHTML = t("The timetable has been cleared.");
     localStorage.setItem("timetableGenerated", "false");
 }
 
-function getCourseDay(timeText) {
-    return timeText.split(" ")[0];
-}
+function getCourseDay(timeText) { return timeText.split(" ")[0]; }
+function getCourseStartTime(timeText) { return timeText.split(" ")[1].split("–")[0]; }
 
-function getCourseStartTime(timeText) {
-    const timePart = timeText.split(" ")[1];
-    return timePart.split("–")[0];
-}
-
-document.addEventListener("DOMContentLoaded", function () {
-    applySavedTheme();
-    loadCoursesFromBackend();
-    loadSelectedCoursesFromBackend();
-});
+// ---------------------------------------------------------------------------
+// Dashboard stats
+// ---------------------------------------------------------------------------
 
 function loadDashboardStats() {
-    const savedCourses =
-        JSON.parse(localStorage.getItem("selectedCourses")) || [];
-
-    const savedDegree =
-        localStorage.getItem("selectedDegree") || "Not selected";
-
-    const courseProgress =
-        document.getElementById("dashboard-course-progress");
-
-    const timetableProgress =
-        document.getElementById("dashboard-timetable-progress");
-
+    const savedCourses = JSON.parse(localStorage.getItem("selectedCourses")) || [];
+    const savedDegree = localStorage.getItem("selectedDegree") || "Not selected";
+    let totalCredits = 0;
+    savedCourses.forEach(c => { totalCredits += c.credits; });
     const courseCount = savedCourses.length;
 
-    let totalCredits = 0;
+    const courseCountTop = document.getElementById("dashboard-course-count");
+    const degreeName = document.getElementById("dashboard-degree-name");
+    const degreeStatus = document.getElementById("dashboard-degree-status");
+    const timetableStatus = document.getElementById("dashboard-timetable-status");
+    const selectedCount = document.getElementById("dashboard-selected-count");
+    const creditTotal = document.getElementById("dashboard-credit-total");
+    const courseProgress = document.getElementById("dashboard-course-progress");
+    const timetableProgress = document.getElementById("dashboard-timetable-progress");
+    const timetableGenerated = localStorage.getItem("timetableGenerated");
 
-    savedCourses.forEach(function (course) {
-        totalCredits += course.credits;
-    });
-
-    const courseCountTop =
-        document.getElementById("dashboard-course-count");
-
-    const degreeName =
-        document.getElementById("dashboard-degree-name");
-
-    const degreeStatus =
-        document.getElementById("dashboard-degree-status");
-
-    const timetableStatus =
-        document.getElementById("dashboard-timetable-status");
-
-    const selectedCount =
-        document.getElementById("dashboard-selected-count");
-
-    const creditTotal =
-        document.getElementById("dashboard-credit-total");
-
-    if (courseCountTop) {
-        courseCountTop.innerHTML = courseCount;
-    }
-
-    if (degreeName) {
-        degreeName.innerHTML = savedDegree;
-    }
-
-    if (degreeStatus) {
-        degreeStatus.innerHTML =
-            savedDegree !== "Not selected" ? "Yes" : "No";
-    }
-
-    const timetableGenerated =
-        localStorage.getItem("timetableGenerated");
-
-    if (timetableStatus) {
-        timetableStatus.innerHTML =
-            timetableGenerated === "true" && courseCount > 0 ? "Yes" : "No";
-    }
-
-    if (selectedCount) {
-        selectedCount.innerHTML = courseCount;
-    }
-
-    if (creditTotal) {
-        creditTotal.innerHTML = totalCredits;
-    }
+    if (courseCountTop) courseCountTop.innerHTML = courseCount;
+    if (degreeName) degreeName.innerHTML = savedDegree;
+    if (degreeStatus) degreeStatus.innerHTML = savedDegree !== "Not selected" ? "Yes" : "No";
+    if (timetableStatus) timetableStatus.innerHTML = (timetableGenerated === "true" && courseCount > 0) ? "Yes" : "No";
+    if (selectedCount) selectedCount.innerHTML = courseCount;
+    if (creditTotal) creditTotal.innerHTML = totalCredits;
 
     if (courseProgress) {
-        courseProgress.innerHTML =
-            courseCount > 0 ? "Done" : "Pending";
-
-        courseProgress.className =
-            courseCount > 0
-                ? "progress-done"
-                : "progress-pending";
+        courseProgress.innerHTML = courseCount > 0 ? "Done" : "Pending";
+        courseProgress.className = courseCount > 0 ? "progress-done" : "progress-pending";
     }
-
     if (timetableProgress) {
-
         if (timetableGenerated === "true" && courseCount > 0) {
-
             timetableProgress.innerHTML = "Generated";
             timetableProgress.className = "progress-done";
-
         } else if (courseCount > 0) {
-
             timetableProgress.innerHTML = "Ready";
             timetableProgress.className = "progress-active";
-
         } else {
-
             timetableProgress.innerHTML = "Pending";
             timetableProgress.className = "progress-pending";
         }
     }
 }
 
+// ---------------------------------------------------------------------------
+// Restore form on page load
+// ---------------------------------------------------------------------------
+
 function restoreCourseSelectionForm() {
     const savedStudyLevel = localStorage.getItem("selectedStudyLevel");
     const savedDegree = localStorage.getItem("selectedDegree");
-
     const studyLevelSelect = document.getElementById("study-level-select");
     const degreeSelect = document.getElementById("degree-select");
 
-    if (!studyLevelSelect || !degreeSelect || !savedStudyLevel) {
-        return;
-    }
+    if (!studyLevelSelect || !degreeSelect || !savedStudyLevel) return;
 
     studyLevelSelect.value = savedStudyLevel;
-
     updateDegreeOptions(false);
 
     if (savedDegree) {
         degreeSelect.value = savedDegree;
-
         const degreeSummary = document.getElementById("degree-summary");
         const courseMessage = document.getElementById("course-message");
-
-        if (degreeSummary) {
-            degreeSummary.textContent = savedDegree;
-        }
-
-        if (courseMessage) {
-            courseMessage.textContent =
-                savedDegree + " selected. You can now add courses to your study plan.";
-        }
-
+        if (degreeSummary) degreeSummary.textContent = savedDegree;
+        if (courseMessage) courseMessage.textContent = savedDegree + " selected. You can now add courses to your study plan.";
         displayAvailableCourses(savedDegree);
     }
 }
 
+// ---------------------------------------------------------------------------
+// Admin — approve / reject change requests
+// ---------------------------------------------------------------------------
+
+function approveChange(requestId) {
+    if (!confirm(t("Approve this change request? The student's enrollment will be updated immediately."))) return;
+
+    fetch("/api/admin/approve-change/" + requestId, { method: "POST" })
+        .then(r => r.json())
+        .then(function (data) {
+            alert(data.message || "Change approved.");
+            location.reload();
+        })
+        .catch(err => console.log("Approve failed:", err));
+}
+
+function rejectChange(requestId) {
+    if (!confirm(t("Reject this change request? The student's current enrollment will remain unchanged."))) return;
+
+    fetch("/api/admin/reject-change/" + requestId, { method: "POST" })
+        .then(r => r.json())
+        .then(function (data) {
+            alert(data.message || "Change rejected.");
+            location.reload();
+        })
+        .catch(err => console.log("Reject failed:", err));
+}
+
+// ---------------------------------------------------------------------------
+// CSV download
+// ---------------------------------------------------------------------------
+
 function downloadTimetable() {
-
-    const savedCourses =
-        JSON.parse(localStorage.getItem("selectedCourses")) || [];
-
-    const output =
-        document.getElementById("timetable-output");
+    const savedCourses = JSON.parse(localStorage.getItem("selectedCourses")) || [];
+    const output = document.getElementById("timetable-output");
 
     if (savedCourses.length === 0) {
-
-        if (output) {
-            output.innerHTML =
-                "Please select courses before downloading a timetable.";
-        }
-
+        if (output) output.innerHTML = "Please select courses before downloading a timetable.";
         return;
     }
 
-    let csvContent =
-        "Course Code,Course Name,Credits,Time,Stream,Semester\n";
-
+    let csvContent = "Course Code,Course Name,Credits,Time,Stream,Semester\n";
     savedCourses.forEach(function (course) {
-
-        csvContent +=
-            `"${course.code}","${course.name}",${course.credits},"${course.time}","${course.stream}","${course.semester}"\n`;
+        csvContent += `"${course.code}","${course.name}",${course.credits},"${course.time}","${course.stream}","${course.semester}"\n`;
     });
 
-    const blob =
-        new Blob([csvContent], { type: "text/csv" });
-
-    const downloadLink =
-        document.createElement("a");
-
-    downloadLink.href =
-        window.URL.createObjectURL(blob);
-
-    downloadLink.download =
-        "timetable.csv";
-
+    const blob = new Blob([csvContent], { type: "text/csv" });
+    const downloadLink = document.createElement("a");
+    downloadLink.href = window.URL.createObjectURL(blob);
+    downloadLink.download = "timetable.csv";
     downloadLink.click();
 
-    if (output) {
-        output.innerHTML =
-            "Timetable downloaded successfully.";
-    }
+    if (output) output.innerHTML = "Timetable downloaded successfully.";
 }
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+document.addEventListener("DOMContentLoaded", function () {
+    applySavedTheme();
+    loadCoursesFromBackend();
+    loadSelectedCoursesFromBackend();
+});

--- a/templates/admin-dashboard.html
+++ b/templates/admin-dashboard.html
@@ -26,15 +26,22 @@
                 <strong>{{ total_users }}</strong>
             </div>
 
-           <div class="status-row">
-               <span>{{ _('Available courses') }}</span>
-               <strong>{{ total_courses }}</strong>
-           </div>
+            <div class="status-row">
+                <span>{{ _('Available courses') }}</span>
+                <strong>{{ total_courses }}</strong>
+            </div>
 
-           <div class="status-row">
-               <span>{{ _('Timetables created') }}</span>
-               <strong>{{ timetables_created }}</strong>
-           </div>
+            <div class="status-row">
+                <span>{{ _('Timetables created') }}</span>
+                <strong>{{ timetables_created }}</strong>
+            </div>
+
+            <div class="status-row">
+                <span>{{ _('Pending change requests') }}</span>
+                <strong class="{% if pending_change_count > 0 %}admin-badge--alert{% endif %}">
+                    {{ pending_change_count }}
+                </strong>
+            </div>
         </div>
     </section>
 
@@ -48,28 +55,111 @@
         </div>
 
         <div class="mini-card admin-stat-card">
-    <span class="mini-icon glyphicon glyphicon-book"></span>
-    <p class="mini-label">{{ _('Courses') }}</p>
-    <h3>{{ total_courses }}</h3>
-    <p class="mini-note">{{ _('Courses available for planning') }}</p>
-</div>
+            <span class="mini-icon glyphicon glyphicon-book"></span>
+            <p class="mini-label">{{ _('Courses') }}</p>
+            <h3>{{ total_courses }}</h3>
+            <p class="mini-note">{{ _('Courses available for planning') }}</p>
+        </div>
 
-<div class="mini-card admin-stat-card">
-    <span class="mini-icon glyphicon glyphicon-stats"></span>
-    <p class="mini-label">{{ _('Selections') }}</p>
-    <h3>{{ total_selections }}</h3>
-    <p class="mini-note">{{ _('Course selections recorded') }}</p>
-</div>
+        <div class="mini-card admin-stat-card">
+            <span class="mini-icon glyphicon glyphicon-stats"></span>
+            <p class="mini-label">{{ _('Selections') }}</p>
+            <h3>{{ total_selections }}</h3>
+            <p class="mini-note">{{ _('Course selections recorded') }}</p>
+        </div>
 
-<div class="mini-card admin-stat-card">
-    <span class="mini-icon glyphicon glyphicon-calendar"></span>
-    <p class="mini-label">{{ _('Timetables') }}</p>
-    <h3>{{ timetables_created }}</h3>
-    <p class="mini-note">{{ _('Generated timetable plans') }}</p>
-</div>
+        <div class="mini-card admin-stat-card {% if pending_change_count > 0 %}admin-stat-card--alert{% endif %}">
+            <span class="mini-icon glyphicon glyphicon-transfer"></span>
+            <p class="mini-label">{{ _('Change Requests') }}</p>
+            <h3>{{ pending_change_count }}</h3>
+            <p class="mini-note">{{ _('Pending admin review') }}</p>
+        </div>
 
     </section>
 
+    {# ------------------------------------------------------------------ #}
+    {# Pending Enrollment Change Requests                                   #}
+    {# ------------------------------------------------------------------ #}
+    <section class="dashboard-panel" id="pending-changes-section">
+        <div class="panel-title-row">
+            <div>
+                <p class="dashboard-kicker">{{ _('Enrollment management') }}</p>
+                <h2>{{ _('Pending Change Requests') }}</h2>
+            </div>
+            {% if pending_change_count > 0 %}
+            <span class="admin-pending-badge">{{ pending_change_count }} {{ _('pending') }}</span>
+            {% endif %}
+        </div>
+
+        <div class="admin-table-wrapper">
+            <table class="table admin-table">
+                <thead>
+                    <tr>
+                        <th>{{ _('Student') }}</th>
+                        <th>{{ _('Current Degree') }}</th>
+                        <th>{{ _('Requested Degree') }}</th>
+                        <th>{{ _('Courses') }}</th>
+                        <th>{{ _('Submitted') }}</th>
+                        <th>{{ _('Action') }}</th>
+                    </tr>
+                </thead>
+
+                <tbody>
+                    {% if pending_changes %}
+                        {% for req in pending_changes %}
+                        <tr>
+                            <td>
+                                <strong>{{ req.student_name }}</strong>
+                                <br>
+                                <small class="text-muted">{{ req.student_id }}</small>
+                            </td>
+                            <td>{{ req.current_degree }}</td>
+                            <td>
+                                {% if req.requested_degree != req.current_degree %}
+                                    <span class="admin-changed-value">{{ req.requested_degree }}</span>
+                                {% else %}
+                                    {{ req.requested_degree }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                <span title="{{ req.requested_courses | join(', ') }}">
+                                    {{ req.course_count }} {{ _('course(s)') }}
+                                </span>
+                            </td>
+                            <td>
+                                <small>{{ req.created_at }}</small>
+                            </td>
+                            <td class="admin-action-cell">
+                                <button
+                                    type="button"
+                                    class="btn btn-sm dashboard-btn-primary"
+                                    onclick="approveChange({{ req.id }})">
+                                    {{ _('Approve') }}
+                                </button>
+                                <button
+                                    type="button"
+                                    class="btn btn-sm dashboard-btn-secondary"
+                                    onclick="rejectChange({{ req.id }})">
+                                    {{ _('Reject') }}
+                                </button>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    {% else %}
+                        <tr>
+                            <td colspan="6" class="admin-empty-row">
+                                {{ _('No pending change requests. All enrollments are up to date.') }}
+                            </td>
+                        </tr>
+                    {% endif %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    {# ------------------------------------------------------------------ #}
+    {# Recent Users + Popular Courses                                       #}
+    {# ------------------------------------------------------------------ #}
     <section class="dashboard-overview-grid admin-management-grid">
 
         <div class="dashboard-panel dashboard-panel-large">
@@ -82,45 +172,53 @@
 
             <div class="admin-table-wrapper">
                 <table class="table admin-table">
-
                     <thead>
                         <tr>
                             <th>{{ _('Name') }}</th>
                             <th>{{ _('Email') }}</th>
                             <th>{{ _('Student ID') }}</th>
+                            <th>{{ _('Enrollment') }}</th>
                             <th>{{ _('Status') }}</th>
                         </tr>
                     </thead>
 
-                  <tbody>
-    {% if recent_users %}
-        {% for user in recent_users %}
-        <tr>
-            <td>{{ user.full_name }}</td>
-            <td>{{ user.email }}</td>
-            <td>{{ user.student_id }}</td>
-            <td>
-                {% if user.selected_count > 0 %}
-                    <span class="admin-status active">
-                        {{ _('Active') }} · {{ user.selected_count }} {{ _('selected') }}
-                    </span>
-                {% else %}
-                    <span class="admin-status pending">
-                        {{ _('No selections') }}
-                    </span>
-                {% endif %}
-            </td>
-        </tr>
-        {% endfor %}
-    {% else %}
-        <tr>
-            <td colspan="4">
-                {{ _('No registered users found.') }}
-            </td>
-        </tr>
-    {% endif %}
-</tbody>
-
+                    <tbody>
+                        {% if recent_users %}
+                            {% for user in recent_users %}
+                            <tr>
+                                <td>{{ user.full_name }}</td>
+                                <td>{{ user.email }}</td>
+                                <td>{{ user.student_id }}</td>
+                                <td>
+                                    {% if user.enrollment_status == 'enrolled' %}
+                                        <span class="admin-status admin-status--enrolled">{{ _('Enrolled') }}</span>
+                                    {% elif user.enrollment_status == 'change_requested' %}
+                                        <span class="admin-status admin-status--pending">{{ _('Change Pending') }}</span>
+                                    {% else %}
+                                        <span class="admin-status admin-status--planning">{{ _('Planning') }}</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if user.selected_count > 0 %}
+                                        <span class="admin-status active">
+                                            {{ _('Active') }} · {{ user.selected_count }} {{ _('selected') }}
+                                        </span>
+                                    {% else %}
+                                        <span class="admin-status pending">
+                                            {{ _('No selections') }}
+                                        </span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        {% else %}
+                            <tr>
+                                <td colspan="5">
+                                    {{ _('No registered users found.') }}
+                                </td>
+                            </tr>
+                        {% endif %}
+                    </tbody>
                 </table>
             </div>
         </div>
@@ -132,25 +230,28 @@
 
             <div class="progress-list admin-course-list">
 
-    {% if popular_courses %}
-        {% for course in popular_courses %}
-        <div class="progress-item">
-            <span>{{ course.code }} - {{ course.name }}</span>
-            <strong>{{ course.selection_count }} {{ _('selections') }}</strong>
-        </div>
-        {% endfor %}
-    {% else %}
-        <div class="progress-item">
-            <span>{{ _('No course selections recorded yet.') }}</span>
-            <strong>0</strong>
-        </div>
-    {% endif %}
+                {% if popular_courses %}
+                    {% for course in popular_courses %}
+                    <div class="progress-item">
+                        <span>{{ course.code }} - {{ course.name }}</span>
+                        <strong>{{ course.selection_count }} {{ _('selections') }}</strong>
+                    </div>
+                    {% endfor %}
+                {% else %}
+                    <div class="progress-item">
+                        <span>{{ _('No course selections recorded yet.') }}</span>
+                        <strong>0</strong>
+                    </div>
+                {% endif %}
 
-</div>
+            </div>
         </div>
 
     </section>
 
+    {# ------------------------------------------------------------------ #}
+    {# Quick Management Tools                                               #}
+    {# ------------------------------------------------------------------ #}
     <section class="dashboard-panel">
 
         <div class="panel-title-row">
@@ -164,13 +265,8 @@
 
             <div class="action-box">
                 <span class="action-icon glyphicon glyphicon-user"></span>
-
                 <h3>{{ _('View Users') }}</h3>
-
-                <p>
-                    {{ _('Review registered users and account status information.') }}
-                </p>
-
+                <p>{{ _('Review registered users and account status information.') }}</p>
                 <button type="button"
                     class="btn dashboard-btn-secondary"
                     data-message="{{ _('User management tools will be connected to database records in a future update.') }}"
@@ -181,13 +277,8 @@
 
             <div class="action-box">
                 <span class="action-icon glyphicon glyphicon-book"></span>
-
                 <h3>{{ _('Manage Courses') }}</h3>
-
-                <p>
-                    {{ _('Check available courses and prepare future course management features.') }}
-                </p>
-
+                <p>{{ _('Check available courses and prepare future course management features.') }}</p>
                 <button type="button"
                     class="btn dashboard-btn-secondary"
                     data-message="{{ _('Course management tools will be expanded in the next development stage.') }}"
@@ -198,16 +289,11 @@
 
             <div class="action-box">
                 <span class="action-icon glyphicon glyphicon-stats"></span>
-
                 <h3>{{ _('View Statistics') }}</h3>
-
-                <p>
-                    {{ _('Monitor course demand and timetable usage across the system.') }}
-                </p>
-
+                <p>{{ _('Monitor course demand and timetable usage across the system.') }}</p>
                 <button type="button"
                     class="btn dashboard-btn-secondary"
-                   data-message="{{ _('Statistics are now calculated from current user and course selection records.') }}"
+                    data-message="{{ _('Statistics are now calculated from current user and course selection records.') }}"
                     onclick="showDashboardMessage(this.dataset.message)">
                     {{ _('View Statistics') }}
                 </button>
@@ -215,13 +301,8 @@
 
             <div class="action-box">
                 <span class="action-icon glyphicon glyphicon-calendar"></span>
-
                 <h3>{{ _('Monitor Timetables') }}</h3>
-
-                <p>
-                    {{ _('Review how many timetable plans have been created by students.') }}
-                </p>
-
+                <p>{{ _('Review how many timetable plans have been created by students.') }}</p>
                 <button type="button"
                     class="btn dashboard-btn-secondary"
                     data-message="{{ _('Timetable monitoring will use real timetable data in a later update.') }}"
@@ -235,15 +316,11 @@
     </section>
 
     <section class="dashboard-panel dashboard-message-panel">
-
         <p class="dashboard-kicker">{{ _('Admin message') }}</p>
-
         <h2>{{ _('System Management Updates') }}</h2>
-
         <p id="dashboard-output">
             {{ _('Use this admin dashboard to monitor users, courses, statistics, and timetable usage.') }}
         </p>
-
     </section>
 
 </div>

--- a/templates/admin-login.html
+++ b/templates/admin-login.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
-{% block title %}{{ _('Course Planner - Admin Login') }}{% endblock %}
+{% block title %}{{ _('UniPlanner - Admin Login') }}{% endblock %}
 
 {% block nav %}
 <nav class="auth-links">
     <a href="{{ url_for('index') }}">{{ _('Student Sign In') }}</a>
     <a href="{{ url_for('signup') }}">{{ _('Sign Up') }}</a>
-    <a href="{{ url_for('admin_login') }}" class="active">{{ _('Admin Login') }}</a>
+    <a href="{{ url_for('admin_login') }}" class="active">{{ _('Admin') }}</a>
 </nav>
 {% endblock %}
 
@@ -26,7 +26,7 @@
 
             <section class="signin-card">
                 <div class="signin-card-header">
-                    <h2>{{ _('Admin login') }}</h2>
+                    <h2>{{ _('Admin Login') }}</h2>
                     <p>{{ _('Only authorised administrator accounts can access this area.') }}</p>
                 </div>
 

--- a/templates/course-selection.html
+++ b/templates/course-selection.html
@@ -39,6 +39,21 @@
         </div>
     </section>
 
+    {#
+        Enrollment status banner — hidden by default.
+        JavaScript (lockEnrollmentUI / requestChange) toggles visibility
+        and sets the correct class and message based on enrollment_status:
+          .enrollment-banner--enrolled    → green / locked
+          .enrollment-banner--pending     → amber / pending
+          .enrollment-banner--draft       → blue / drafting a change
+    #}
+    <div id="enrollment-status-banner"
+         class="enrollment-banner"
+         style="display: none;"
+         role="status"
+         aria-live="polite">
+    </div>
+
     <section class="course-layout">
         <div class="course-main-column">
 
@@ -161,12 +176,47 @@
                     <strong id="credit-output">0</strong>
                 </div>
 
+                {#
+                    Confirm Enrollment button — visible while the student is in
+                    'planning' status and has selected at least one course.
+                    Hidden by JS once they are enrolled.
+                #}
+                <button id="confirm-enrollment-btn"
+                    type="button"
+                    class="btn dashboard-btn-primary selected-next-btn"
+                    onclick="confirmEnrollment()"
+                    style="display: none;">
+                    {{ _('Confirm Enrollment') }}
+                </button>
+
+                {#
+                    Request Change button — visible only when enrollment_status
+                    is 'enrolled'.  Clicking this enters change-request draft mode.
+                #}
+                <button id="request-change-btn"
+                    type="button"
+                    class="btn dashboard-btn-secondary selected-next-btn enrollment-action-btn"
+                    onclick="requestChange()"
+                    style="display: none;">
+                    {{ _('Request Change') }}
+                </button>
+
+                {#
+                    Pending notice — visible only when enrollment_status is
+                    'change_requested'.  No action available while pending.
+                #}
+                <div id="pending-change-notice"
+                     class="pending-change-notice"
+                     style="display: none;">
+                    <span class="pending-change-notice__icon">⏳</span>
+                    <p>{{ _('Your change request is awaiting admin approval. No further changes can be made until it is reviewed.') }}</p>
+                </div>
+
                 <a href="{{ url_for('timetable') }}"
                     class="btn dashboard-btn-secondary selected-next-btn">
-
                     {{ _('Continue to Timetable') }}
-
                 </a>
+
             </section>
         </aside>
     </section>

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -1,6 +1,6 @@
 {% extends "dashboard-base.html" %}
 
-{% block title %}{{ _('Course Planner - Dashboard') }}{% endblock %}
+{% block title %}{{ _('UniPlanner - Dashboard') }}{% endblock %}
 
 {% block content %}
 <div class="container dashboard-container">

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ _('Course Planner - Sign Up') }}{% endblock %}
+{% block title %}{{ _('UniPlanner - Sign Up') }}{% endblock %}
 
 {% block nav %}
 <nav class="auth-links">


### PR DESCRIPTION
Fixes the enrollment flow so students can't freely change their degree and courses after registering.

## Problem
A student could log back in and change their degree or courses with no restrictions, which doesn't reflect real university enrollment.

## Solution
Added a three-state enrollment lifecycle: `planning` → `enrolled` → `change_requested`

- **Planning**: freely add/remove courses and select a degree
- **Enrolled**: selection is locked after clicking Confirm Enrollment
- **Change Requested**: student submits a change request, admin approves or rejects it

## Files Changed
- `app.py` — new models and endpoints
- `course-selection.html` — confirm button, request change button, status banner
- `admin-dashboard.html` — pending change requests table with approve/reject
- `script.js` — enrollment state machine
- `style.css` — new status styles

Closes #91 