### PR TITLE
Improve dark mode consistency for courses and timetable

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2584,6 +2584,7 @@ body.dark-mode .app-header {
     cursor: not-allowed;
     border: none;
     opacity: 1;
+}
 .enrollment-banner {
     display: flex;
     align-items: flex-start;
@@ -2649,7 +2650,8 @@ body.dark-mode .app-header {
     color: #7ac4f0;
 }
 
-/* ===================================================================   Sidebar — confirm & request-change buttons
+/* ==========================================================================
+   Sidebar — confirm & request-change buttons
    ========================================================================== */
 
 .enrollment-action-btn {
@@ -2658,7 +2660,8 @@ body.dark-mode .app-header {
     text-align: center;
 }
 
-/* ===================================================================   Pending change notice (inside sidebar)
+/* ==========================================================================
+   Pending change notice (inside sidebar)
    ========================================================================== */
 
 .pending-change-notice {
@@ -2687,7 +2690,8 @@ body.dark-mode .app-header {
     color: #ffd54f;
 }
 
-/* ===================================================================   Admin dashboard — change request styles
+/* ==========================================================================
+   Admin dashboard — change request styles
    ========================================================================== */
 
 /* Orange stat card when there are pending requests */
@@ -2775,4 +2779,162 @@ body.dark-mode .app-header {
 .dark-mode .admin-status--planning {
     background-color: #2d3748;
     color: #a0aec0;
+}
+
+/* ===== Strong dark mode fix for available courses table/tiles ===== */
+
+body.dark-mode #available-courses,
+body.dark-mode .course-table {
+    background: transparent;
+}
+
+body.dark-mode #available-courses .course-table-header {
+    background: #111827;
+    color: #f8fafc;
+    border: 1px solid #334155;
+}
+
+body.dark-mode #available-courses .course-table-row {
+    background: #1e293b !important;
+    border: 1px solid #334155 !important;
+    color: #e5e7eb;
+}
+
+body.dark-mode #available-courses .course-table-row:hover {
+    background: #273449 !important;
+    border-color: #475569 !important;
+}
+
+body.dark-mode #available-courses .course-table-row span {
+    color: #e5e7eb;
+}
+
+body.dark-mode #available-courses .course-table-name {
+    color: #f8fafc;
+}
+
+body.dark-mode #available-courses .course-code {
+    background: #60a5fa;
+    color: #0f172a !important;
+}
+
+body.dark-mode #available-courses .dashboard-btn-primary {
+    background: #60a5fa;
+    color: #0f172a;
+    border: none;
+}
+
+body.dark-mode #available-courses .dashboard-btn-primary:hover {
+    background: #93c5fd;
+    color: #0f172a;
+}
+
+/* ===== Dark mode fixes for course filter/search box ===== */
+
+body.dark-mode .course-filter-bar {
+    background: #1e293b;
+    border-color: #334155;
+}
+
+body.dark-mode .course-filter-bar .form-control {
+    background-color: #0f172a;
+    color: #f8fafc;
+    border-color: #475569;
+}
+
+body.dark-mode .course-filter-bar .form-control::placeholder {
+    color: #94a3b8;
+}
+
+/* Only selected/disabled Added buttons should look disabled */
+
+.course-table-row button.added-course-btn:disabled {
+    background: #d9e2ec !important;
+    color: #5f6b76 !important;
+    border: 1px solid #c7d3df !important;
+    cursor: not-allowed !important;
+    box-shadow: none !important;
+}
+
+/* Keep normal Add buttons unchanged */
+
+.course-table-row button.dashboard-btn-primary:not(.added-course-btn) {
+    background: #183b5b !important;
+    color: white !important;
+    border: none !important;
+}
+
+/* Dark mode Added button */
+
+body.dark-mode .course-table-row button.added-course-btn:disabled {
+    background: #334155 !important;
+    color: #94a3b8 !important;
+    border: 1px solid #475569 !important;
+    cursor: not-allowed !important;
+    box-shadow: none !important;
+}
+
+/* Dark mode normal Add button */
+
+body.dark-mode .course-table-row button.dashboard-btn-primary:not(.added-course-btn) {
+    background: #60a5fa !important;
+    color: #0f172a !important;
+    border: none !important;
+}
+
+/* ===== Dark mode fix for selected courses section ===== */
+
+body.dark-mode .selected-course-item {
+    background: #0f172a;
+    border-color: #334155;
+}
+
+body.dark-mode .selected-course-info strong {
+    color: #f8fafc;
+}
+
+body.dark-mode .selected-course-info span {
+    color: #cbd5e1;
+}
+
+body.dark-mode .remove-course-btn {
+    background: #7f1d1d;
+    color: #fecaca;
+}
+
+/* ===== Dark mode fix for generated timetable grid ===== */
+
+body.dark-mode .weekly-calendar {
+    background: #0f172a;
+    border-color: #334155;
+}
+
+body.dark-mode .calendar-time {
+    background: #111827;
+    color: #cbd5e1;
+    border-top-color: #334155;
+}
+
+body.dark-mode .calendar-cell {
+    background: #0f172a;
+    border-top-color: #334155;
+    border-left-color: #334155;
+}
+
+body.dark-mode .course-block {
+    background: #1e293b;
+    color: #f8fafc;
+    border-left-color: #60a5fa;
+}
+
+body.dark-mode .course-block strong {
+    color: #93c5fd;
+}
+
+body.dark-mode .course-block span {
+    color: #f8fafc;
+}
+
+body.dark-mode .course-block small {
+    color: #cbd5e1;
 }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -366,12 +366,8 @@ function lockEnrollmentUI(status) {
     if (studyLevelSelect) studyLevelSelect.disabled = true;
     if (degreeSelect) degreeSelect.disabled = true;
 
-    // Disable all Add buttons in the course table
-    document.querySelectorAll("[data-course-code]").forEach(function (btn) {
-        btn.disabled = true;
-        btn.textContent = "Added";
-        btn.classList.add("added-course-btn");
-    });
+    // Disable course buttons while keeping selected courses visually different
+    updateAddButtonStates();
 
     // Show enrollment status banner
     const banner = document.getElementById("enrollment-status-banner");
@@ -732,7 +728,7 @@ function displayAvailableCourses(degreeName) {
                     <span>${course.time}</span>
                     <span>${course.credits} credits</span>
                     <button type="button"
-                        class="btn dashboard-btn-primary${isLocked ? ' added-course-btn' : ''}"
+                        class="btn dashboard-btn-primary"
                         data-course-code="${course.code}"
                         ${isLocked ? 'disabled' : ''}
                         onclick="addCourse(event,'${course.code}','${course.name}',${course.credits},'${course.time}','${course.degree}','${course.semester}')">
@@ -757,7 +753,12 @@ function updateAddButtonStates() {
         if (isLocked || isSelected) {
             button.textContent = isSelected ? "Added" : "Add";
             button.disabled = true;
-            button.classList.add("added-course-btn");
+
+            if (isSelected) {
+                button.classList.add("added-course-btn");
+            } else {
+            button.classList.remove("added-course-btn");
+            }
         } else {
             button.textContent = "Add";
             button.disabled = false;

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -6,7 +6,7 @@
 <nav class="auth-links">
     <a href="{{ url_for('index') }}">{{ _('Sign In') }}</a>
     <a href="{{ url_for('signup') }}" class="active">{{ _('Sign Up') }}</a>
-    <a href="{{ url_for('admin_login') }}">{{ _('Admin Login') }}</a>
+    <a href="{{ url_for('admin_login') }}">{{ _('Admin') }}</a>
 </nav>
 {% endblock %}
 


### PR DESCRIPTION
Improves dark mode consistency across the course selection and timetable pages.

### Changes
- Added dark mode styling for available course tiles
- Added dark mode styling for selected course cards
- Added dark mode styling for timetable grid and generated timetable blocks
- Improved dark mode styling for course search/filter section
- Updated `Added` buttons to look disabled
- Kept normal `Add` buttons visually active
- Refactored course button state logic in `script.js`

Closes #93