### PR TITLE
Expand course dataset for study levels and semesters

### DIFF
--- a/data/courses.json
+++ b/data/courses.json
@@ -16,14 +16,6 @@
     "degree": "Bachelor of Arts"
   },
   {
-    "code": "PHIL1002",
-    "name": "Introduction to Critical Thinking",
-    "credits": 6,
-    "time": "Thursday 11:00–13:00",
-    "semester": "semester1",
-    "degree": "Bachelor of Arts"
-  },
-  {
     "code": "LING1001",
     "name": "Language and Communication",
     "credits": 6,
@@ -32,11 +24,27 @@
     "degree": "Bachelor of Arts"
   },
   {
+    "code": "PHIL1002",
+    "name": "Introduction to Critical Thinking",
+    "credits": 6,
+    "time": "Thursday 11:00–13:00",
+    "semester": "semester1",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "COMM2001",
+    "name": "Digital Communication",
+    "credits": 6,
+    "time": "Friday 13:00–15:00",
+    "semester": "semester2",
+    "degree": "Bachelor of Arts"
+  },
+  {
     "code": "ENGL2402",
     "name": "Modern Literature",
     "credits": 6,
-    "time": "Monday 10:00–12:00",
-    "semester": "semester1",
+    "time": "Monday 13:00–15:00",
+    "semester": "semester2",
     "degree": "Bachelor of Arts"
   },
   {
@@ -56,14 +64,197 @@
     "degree": "Bachelor of Arts"
   },
   {
-    "code": "COMM2001",
-    "name": "Digital Communication",
+    "code": "ARTS301",
+    "name": "Writing and Research Skills",
     "credits": 6,
-    "time": "Friday 13:00–15:00",
-    "semester": "semester2",
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester3",
     "degree": "Bachelor of Arts"
   },
-
+  {
+    "code": "ARTS302",
+    "name": "World Literature",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS303",
+    "name": "Media and Culture",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS304",
+    "name": "Creative Writing",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS401",
+    "name": "Cultural Studies",
+    "credits": 6,
+    "time": "Thursday 09:00–11:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS402",
+    "name": "Australian History",
+    "credits": 6,
+    "time": "Thursday 10:00–12:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS403",
+    "name": "Social Theory",
+    "credits": 6,
+    "time": "Thursday 13:00–15:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS404",
+    "name": "Philosophy of Mind",
+    "credits": 6,
+    "time": "Thursday 14:00–16:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS501",
+    "name": "Gender and Society",
+    "credits": 6,
+    "time": "Friday 09:00–11:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS502",
+    "name": "Film Studies",
+    "credits": 6,
+    "time": "Friday 10:00–12:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS503",
+    "name": "Linguistic Analysis",
+    "credits": 6,
+    "time": "Friday 13:00–15:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS504",
+    "name": "Public Communication",
+    "credits": 6,
+    "time": "Friday 14:00–16:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS601",
+    "name": "Political Thought",
+    "credits": 6,
+    "time": "Monday 09:00–11:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS602",
+    "name": "Research in the Humanities",
+    "credits": 6,
+    "time": "Monday 10:00–12:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS603",
+    "name": "Contemporary Asia",
+    "credits": 6,
+    "time": "Monday 13:00–15:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS604",
+    "name": "Indigenous Studies",
+    "credits": 6,
+    "time": "Monday 14:00–16:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS701",
+    "name": "Advanced Writing",
+    "credits": 6,
+    "time": "Tuesday 09:00–11:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS702",
+    "name": "History of Ideas",
+    "credits": 6,
+    "time": "Tuesday 10:00–12:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS703",
+    "name": "Ethics in Practice",
+    "credits": 6,
+    "time": "Tuesday 13:00–15:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS704",
+    "name": "Capstone in Arts",
+    "credits": 6,
+    "time": "Tuesday 14:00–16:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS801",
+    "name": "Global Cultures",
+    "credits": 6,
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS802",
+    "name": "Digital Storytelling",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS803",
+    "name": "Language in Society",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Arts"
+  },
+  {
+    "code": "ARTS804",
+    "name": "Professional Arts Practice",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Arts"
+  },
   {
     "code": "ACCT1101",
     "name": "Financial Accounting",
@@ -81,18 +272,18 @@
     "degree": "Bachelor of Commerce"
   },
   {
-    "code": "MGMT1135",
-    "name": "Organisational Behaviour",
-    "credits": 6,
-    "time": "Friday 12:00–14:00",
-    "semester": "semester1",
-    "degree": "Bachelor of Commerce"
-  },
-  {
     "code": "FNCE1001",
     "name": "Business Finance",
     "credits": 6,
     "time": "Monday 09:00–11:00",
+    "semester": "semester1",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "MGMT1135",
+    "name": "Organisational Behaviour",
+    "credits": 6,
+    "time": "Friday 12:00–14:00",
     "semester": "semester1",
     "degree": "Bachelor of Commerce"
   },
@@ -113,6 +304,14 @@
     "degree": "Bachelor of Commerce"
   },
   {
+    "code": "MGMT2234",
+    "name": "Business Strategy",
+    "credits": 6,
+    "time": "Tuesday 10:00–12:00",
+    "semester": "semester2",
+    "degree": "Bachelor of Commerce"
+  },
+  {
     "code": "MKTG1203",
     "name": "Marketing Principles",
     "credits": 6,
@@ -121,17 +320,200 @@
     "degree": "Bachelor of Commerce"
   },
   {
-    "code": "MGMT2234",
-    "name": "Business Strategy",
+    "code": "BUSN301",
+    "name": "Business Statistics",
     "credits": 6,
-    "time": "Tuesday 10:00–12:00",
-    "semester": "semester2",
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester3",
     "degree": "Bachelor of Commerce"
   },
-
   {
-    "code": "SCIE1106",
-    "name": "Molecular Biology of the Cell",
+    "code": "BUSN302",
+    "name": "Consumer Behaviour",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN303",
+    "name": "Corporate Finance",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN304",
+    "name": "Business Law",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN401",
+    "name": "Human Resource Management",
+    "credits": 6,
+    "time": "Thursday 09:00–11:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN402",
+    "name": "International Business",
+    "credits": 6,
+    "time": "Thursday 10:00–12:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN403",
+    "name": "Cost Accounting",
+    "credits": 6,
+    "time": "Thursday 13:00–15:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN404",
+    "name": "Operations Management",
+    "credits": 6,
+    "time": "Thursday 14:00–16:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN501",
+    "name": "Taxation Principles",
+    "credits": 6,
+    "time": "Friday 09:00–11:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN502",
+    "name": "Entrepreneurship",
+    "credits": 6,
+    "time": "Friday 10:00–12:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN503",
+    "name": "Investment Analysis",
+    "credits": 6,
+    "time": "Friday 13:00–15:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN504",
+    "name": "Data Analytics for Business",
+    "credits": 6,
+    "time": "Friday 14:00–16:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN601",
+    "name": "Leadership and Change",
+    "credits": 6,
+    "time": "Monday 09:00–11:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN602",
+    "name": "Strategic Marketing",
+    "credits": 6,
+    "time": "Monday 10:00–12:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN603",
+    "name": "Auditing",
+    "credits": 6,
+    "time": "Monday 13:00–15:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN604",
+    "name": "Business Information Systems",
+    "credits": 6,
+    "time": "Monday 14:00–16:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN701",
+    "name": "Business Ethics",
+    "credits": 6,
+    "time": "Tuesday 09:00–11:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN702",
+    "name": "Project Management",
+    "credits": 6,
+    "time": "Tuesday 10:00–12:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN703",
+    "name": "Global Strategy",
+    "credits": 6,
+    "time": "Tuesday 13:00–15:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN704",
+    "name": "Commerce Capstone",
+    "credits": 6,
+    "time": "Tuesday 14:00–16:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN801",
+    "name": "Risk Management",
+    "credits": 6,
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN802",
+    "name": "Financial Markets",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN803",
+    "name": "Service Management",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "BUSN804",
+    "name": "Sustainable Business",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Commerce"
+  },
+  {
+    "code": "CHEM1002",
+    "name": "Chemistry Foundations",
     "credits": 6,
     "time": "Monday 14:00–16:00",
     "semester": "semester1",
@@ -146,6 +528,14 @@
     "degree": "Bachelor of Science"
   },
   {
+    "code": "SCIE1106",
+    "name": "Molecular Biology of the Cell",
+    "credits": 6,
+    "time": "Monday 14:00–16:00",
+    "semester": "semester1",
+    "degree": "Bachelor of Science"
+  },
+  {
     "code": "STAT1400",
     "name": "Statistics for Science",
     "credits": 6,
@@ -154,16 +544,16 @@
     "degree": "Bachelor of Science"
   },
   {
-    "code": "CHEM1002",
-    "name": "Chemistry Foundations",
+    "code": "BIOL2201",
+    "name": "Genetics",
     "credits": 6,
-    "time": "Monday 14:00–16:00",
-    "semester": "semester1",
+    "time": "Tuesday 13:00–15:00",
+    "semester": "semester2",
     "degree": "Bachelor of Science"
   },
   {
-    "code": "BIOL2201",
-    "name": "Genetics",
+    "code": "MATH2202",
+    "name": "Linear Algebra",
     "credits": 6,
     "time": "Tuesday 13:00–15:00",
     "semester": "semester2",
@@ -186,14 +576,197 @@
     "degree": "Bachelor of Science"
   },
   {
-    "code": "MATH2202",
-    "name": "Linear Algebra",
+    "code": "SCIE301",
+    "name": "Scientific Practice",
     "credits": 6,
-    "time": "Tuesday 13:00–15:00",
-    "semester": "semester2",
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester3",
     "degree": "Bachelor of Science"
   },
-
+  {
+    "code": "SCIE302",
+    "name": "Earth Systems",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE303",
+    "name": "Environmental Biology",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE304",
+    "name": "Calculus for Science",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE401",
+    "name": "Organic Chemistry",
+    "credits": 6,
+    "time": "Thursday 09:00–11:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE402",
+    "name": "Ecology",
+    "credits": 6,
+    "time": "Thursday 10:00–12:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE403",
+    "name": "Data Analysis in Science",
+    "credits": 6,
+    "time": "Thursday 13:00–15:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE404",
+    "name": "Experimental Design",
+    "credits": 6,
+    "time": "Thursday 14:00–16:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE501",
+    "name": "Microbiology",
+    "credits": 6,
+    "time": "Friday 09:00–11:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE502",
+    "name": "Cell Biology",
+    "credits": 6,
+    "time": "Friday 10:00–12:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE503",
+    "name": "Astrophysics",
+    "credits": 6,
+    "time": "Friday 13:00–15:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE504",
+    "name": "Scientific Computing",
+    "credits": 6,
+    "time": "Friday 14:00–16:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE601",
+    "name": "Advanced Genetics",
+    "credits": 6,
+    "time": "Monday 09:00–11:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE602",
+    "name": "Environmental Modelling",
+    "credits": 6,
+    "time": "Monday 10:00–12:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE603",
+    "name": "Biotechnology",
+    "credits": 6,
+    "time": "Monday 13:00–15:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE604",
+    "name": "Mathematical Modelling",
+    "credits": 6,
+    "time": "Monday 14:00–16:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE701",
+    "name": "Research Methods in Science",
+    "credits": 6,
+    "time": "Tuesday 09:00–11:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE702",
+    "name": "Advanced Statistics",
+    "credits": 6,
+    "time": "Tuesday 10:00–12:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE703",
+    "name": "Science Communication",
+    "credits": 6,
+    "time": "Tuesday 13:00–15:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE704",
+    "name": "Science Capstone",
+    "credits": 6,
+    "time": "Tuesday 14:00–16:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE801",
+    "name": "Marine Science",
+    "credits": 6,
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE802",
+    "name": "Quantum Concepts",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE803",
+    "name": "Computational Biology",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Science"
+  },
+  {
+    "code": "SCIE804",
+    "name": "Climate Science",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Science"
+  },
   {
     "code": "ANHB1101",
     "name": "Human Biology I",
@@ -227,6 +800,22 @@
     "degree": "Bachelor of Biomedical Science"
   },
   {
+    "code": "ANHB2203",
+    "name": "Advanced Anatomy",
+    "credits": 6,
+    "time": "Thursday 10:00–12:00",
+    "semester": "semester2",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BIOC2001",
+    "name": "Biochemistry",
+    "credits": 6,
+    "time": "Tuesday 10:00–12:00",
+    "semester": "semester2",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
     "code": "PATH2001",
     "name": "Pathology Basics",
     "credits": 6,
@@ -243,35 +832,210 @@
     "degree": "Bachelor of Biomedical Science"
   },
   {
-    "code": "ANHB2203",
-    "name": "Advanced Anatomy",
+    "code": "BMED301",
+    "name": "Biomedical Skills",
+    "credits": 6,
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED302",
+    "name": "Human Genetics",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED303",
+    "name": "Health and Disease",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED304",
+    "name": "Foundations of Pharmacology",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED401",
+    "name": "Immunology",
+    "credits": 6,
+    "time": "Thursday 09:00–11:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED402",
+    "name": "Molecular Medicine",
     "credits": 6,
     "time": "Thursday 10:00–12:00",
-    "semester": "semester2",
+    "semester": "semester4",
     "degree": "Bachelor of Biomedical Science"
   },
   {
-    "code": "BIOC2001",
-    "name": "Biochemistry",
+    "code": "BMED403",
+    "name": "Medical Biochemistry",
+    "credits": 6,
+    "time": "Thursday 13:00–15:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED404",
+    "name": "Neuroscience",
+    "credits": 6,
+    "time": "Thursday 14:00–16:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED501",
+    "name": "Infection and Immunity",
+    "credits": 6,
+    "time": "Friday 09:00–11:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED502",
+    "name": "Clinical Anatomy",
+    "credits": 6,
+    "time": "Friday 10:00–12:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED503",
+    "name": "Laboratory Medicine",
+    "credits": 6,
+    "time": "Friday 13:00–15:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED504",
+    "name": "Epidemiology",
+    "credits": 6,
+    "time": "Friday 14:00–16:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED601",
+    "name": "Advanced Physiology",
+    "credits": 6,
+    "time": "Monday 09:00–11:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED602",
+    "name": "Cancer Biology",
+    "credits": 6,
+    "time": "Monday 10:00–12:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED603",
+    "name": "Toxicology",
+    "credits": 6,
+    "time": "Monday 13:00–15:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED604",
+    "name": "Medical Research Methods",
+    "credits": 6,
+    "time": "Monday 14:00–16:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED701",
+    "name": "Biomedical Data Analysis",
+    "credits": 6,
+    "time": "Tuesday 09:00–11:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED702",
+    "name": "Translational Medicine",
     "credits": 6,
     "time": "Tuesday 10:00–12:00",
-    "semester": "semester2",
+    "semester": "semester7",
     "degree": "Bachelor of Biomedical Science"
   },
-
   {
-    "code": "ENGG1100",
-    "name": "Engineering Design",
+    "code": "BMED703",
+    "name": "Clinical Pathology",
+    "credits": 6,
+    "time": "Tuesday 13:00–15:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED704",
+    "name": "Biomedical Science Capstone",
+    "credits": 6,
+    "time": "Tuesday 14:00–16:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED801",
+    "name": "Diagnostic Science",
+    "credits": 6,
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED802",
+    "name": "Reproductive Biology",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED803",
+    "name": "Advanced Microbiology",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "BMED804",
+    "name": "Public Health Biology",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Biomedical Science"
+  },
+  {
+    "code": "CITS1001",
+    "name": "Programming Fundamentals",
     "credits": 6,
     "time": "Monday 10:00–12:00",
     "semester": "semester1",
     "degree": "Bachelor of Engineering"
   },
   {
-    "code": "PHYS1001",
-    "name": "Physics for Engineers",
+    "code": "ENGG1100",
+    "name": "Engineering Design",
     "credits": 6,
-    "time": "Wednesday 09:00–11:00",
+    "time": "Monday 10:00–12:00",
     "semester": "semester1",
     "degree": "Bachelor of Engineering"
   },
@@ -284,19 +1048,11 @@
     "degree": "Bachelor of Engineering"
   },
   {
-    "code": "CITS1001",
-    "name": "Programming Fundamentals",
+    "code": "PHYS1001",
+    "name": "Physics for Engineers",
     "credits": 6,
-    "time": "Monday 10:00–12:00",
+    "time": "Wednesday 09:00–11:00",
     "semester": "semester1",
-    "degree": "Bachelor of Engineering"
-  },
-  {
-    "code": "ENGG2201",
-    "name": "Engineering Mechanics",
-    "credits": 6,
-    "time": "Thursday 13:00–15:00",
-    "semester": "semester2",
     "degree": "Bachelor of Engineering"
   },
   {
@@ -316,6 +1072,14 @@
     "degree": "Bachelor of Engineering"
   },
   {
+    "code": "ENGG2201",
+    "name": "Engineering Mechanics",
+    "credits": 6,
+    "time": "Thursday 13:00–15:00",
+    "semester": "semester2",
+    "degree": "Bachelor of Engineering"
+  },
+  {
     "code": "MECH2201",
     "name": "Thermodynamics",
     "credits": 6,
@@ -323,10 +1087,201 @@
     "semester": "semester2",
     "degree": "Bachelor of Engineering"
   },
-
   {
-    "code": "CITS5505",
-    "name": "Agile Web Development",
+    "code": "ENGG301",
+    "name": "Engineering Computing",
+    "credits": 6,
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG302",
+    "name": "Materials Engineering",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG303",
+    "name": "Systems Engineering",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG304",
+    "name": "Engineering Drawing",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester3",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG401",
+    "name": "Fluid Mechanics",
+    "credits": 6,
+    "time": "Thursday 09:00–11:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG402",
+    "name": "Digital Systems",
+    "credits": 6,
+    "time": "Thursday 10:00–12:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG403",
+    "name": "Surveying and Design",
+    "credits": 6,
+    "time": "Thursday 13:00–15:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG404",
+    "name": "Engineering Statistics",
+    "credits": 6,
+    "time": "Thursday 14:00–16:00",
+    "semester": "semester4",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG501",
+    "name": "Control Systems",
+    "credits": 6,
+    "time": "Friday 09:00–11:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG502",
+    "name": "Project Design",
+    "credits": 6,
+    "time": "Friday 10:00–12:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG503",
+    "name": "Geotechnical Engineering",
+    "credits": 6,
+    "time": "Friday 13:00–15:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG504",
+    "name": "Signals and Systems",
+    "credits": 6,
+    "time": "Friday 14:00–16:00",
+    "semester": "semester5",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG601",
+    "name": "Heat Transfer",
+    "credits": 6,
+    "time": "Monday 09:00–11:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG602",
+    "name": "Software for Engineers",
+    "credits": 6,
+    "time": "Monday 10:00–12:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG603",
+    "name": "Transport Engineering",
+    "credits": 6,
+    "time": "Monday 13:00–15:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG604",
+    "name": "Renewable Energy Systems",
+    "credits": 6,
+    "time": "Monday 14:00–16:00",
+    "semester": "semester6",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG701",
+    "name": "Engineering Management",
+    "credits": 6,
+    "time": "Tuesday 09:00–11:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG702",
+    "name": "Professional Engineering Practice",
+    "credits": 6,
+    "time": "Tuesday 10:00–12:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG703",
+    "name": "Advanced Design Project",
+    "credits": 6,
+    "time": "Tuesday 13:00–15:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG704",
+    "name": "Engineering Capstone",
+    "credits": 6,
+    "time": "Tuesday 14:00–16:00",
+    "semester": "semester7",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG801",
+    "name": "Robotics Fundamentals",
+    "credits": 6,
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG802",
+    "name": "Water Engineering",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG803",
+    "name": "Power Systems",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "ENGG804",
+    "name": "Manufacturing Processes",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester8",
+    "degree": "Bachelor of Engineering"
+  },
+  {
+    "code": "CITS5206",
+    "name": "IT Project Management",
     "credits": 6,
     "time": "Monday 10:00–12:00",
     "semester": "semester1",
@@ -341,35 +1296,19 @@
     "degree": "Master of Information Technology"
   },
   {
-    "code": "CITS5508",
-    "name": "Machine Learning",
-    "credits": 6,
-    "time": "Wednesday 09:00–11:00",
-    "semester": "semester1",
-    "degree": "Master of Information Technology"
-  },
-  {
-    "code": "CITS5206",
-    "name": "IT Project Management",
+    "code": "CITS5505",
+    "name": "Agile Web Development",
     "credits": 6,
     "time": "Monday 10:00–12:00",
     "semester": "semester1",
     "degree": "Master of Information Technology"
   },
   {
-    "code": "CITS4407",
-    "name": "Open Source Tools",
+    "code": "CITS5508",
+    "name": "Machine Learning",
     "credits": 6,
-    "time": "Tuesday 10:00–12:00",
-    "semester": "semester2",
-    "degree": "Master of Information Technology"
-  },
-  {
-    "code": "CITS4012",
-    "name": "Distributed Computing",
-    "credits": 6,
-    "time": "Wednesday 13:00–15:00",
-    "semester": "semester2",
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester1",
     "degree": "Master of Information Technology"
   },
   {
@@ -389,6 +1328,102 @@
     "degree": "Master of Information Technology"
   },
   {
+    "code": "CITS4012",
+    "name": "Distributed Computing",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester2",
+    "degree": "Master of Information Technology"
+  },
+  {
+    "code": "CITS4407",
+    "name": "Open Source Tools",
+    "credits": 6,
+    "time": "Tuesday 10:00–12:00",
+    "semester": "semester2",
+    "degree": "Master of Information Technology"
+  },
+  {
+    "code": "CITS301",
+    "name": "Software Requirements",
+    "credits": 6,
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester3",
+    "degree": "Master of Information Technology"
+  },
+  {
+    "code": "CITS302",
+    "name": "Cloud Computing",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester3",
+    "degree": "Master of Information Technology"
+  },
+  {
+    "code": "CITS303",
+    "name": "Cybersecurity",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester3",
+    "degree": "Master of Information Technology"
+  },
+  {
+    "code": "CITS304",
+    "name": "Database Systems",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester3",
+    "degree": "Master of Information Technology"
+  },
+  {
+    "code": "CITS401",
+    "name": "Software Testing",
+    "credits": 6,
+    "time": "Thursday 09:00–11:00",
+    "semester": "semester4",
+    "degree": "Master of Information Technology"
+  },
+  {
+    "code": "CITS402",
+    "name": "Human Computer Interaction",
+    "credits": 6,
+    "time": "Thursday 10:00–12:00",
+    "semester": "semester4",
+    "degree": "Master of Information Technology"
+  },
+  {
+    "code": "CITS403",
+    "name": "Advanced Algorithms",
+    "credits": 6,
+    "time": "Thursday 13:00–15:00",
+    "semester": "semester4",
+    "degree": "Master of Information Technology"
+  },
+  {
+    "code": "CITS404",
+    "name": "Capstone Project",
+    "credits": 6,
+    "time": "Thursday 14:00–16:00",
+    "semester": "semester4",
+    "degree": "Master of Information Technology"
+  },
+  {
+    "code": "DATA103",
+    "name": "Programming for Data Science",
+    "credits": 6,
+    "time": "Monday 13:00–15:00",
+    "semester": "semester1",
+    "degree": "Master of Data Science"
+  },
+  {
+    "code": "DATA104",
+    "name": "Data Wrangling",
+    "credits": 6,
+    "time": "Monday 14:00–16:00",
+    "semester": "semester1",
+    "degree": "Master of Data Science"
+  },
+  {
     "code": "DATA5508",
     "name": "Machine Learning",
     "credits": 6,
@@ -405,6 +1440,30 @@
     "degree": "Master of Data Science"
   },
   {
+    "code": "DATA202",
+    "name": "Data Visualisation",
+    "credits": 6,
+    "time": "Tuesday 10:00–12:00",
+    "semester": "semester2",
+    "degree": "Master of Data Science"
+  },
+  {
+    "code": "DATA203",
+    "name": "Statistical Learning",
+    "credits": 6,
+    "time": "Tuesday 13:00–15:00",
+    "semester": "semester2",
+    "degree": "Master of Data Science"
+  },
+  {
+    "code": "DATA204",
+    "name": "Big Data Analytics",
+    "credits": 6,
+    "time": "Tuesday 14:00–16:00",
+    "semester": "semester2",
+    "degree": "Master of Data Science"
+  },
+  {
     "code": "DATA5001",
     "name": "Data Science Principles",
     "credits": 6,
@@ -412,13 +1471,124 @@
     "semester": "semester2",
     "degree": "Master of Data Science"
   },
-
+  {
+    "code": "DATA301",
+    "name": "Database Management",
+    "credits": 6,
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester3",
+    "degree": "Master of Data Science"
+  },
+  {
+    "code": "DATA302",
+    "name": "Natural Language Processing",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester3",
+    "degree": "Master of Data Science"
+  },
+  {
+    "code": "DATA303",
+    "name": "Deep Learning",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester3",
+    "degree": "Master of Data Science"
+  },
+  {
+    "code": "DATA304",
+    "name": "Cloud Data Engineering",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester3",
+    "degree": "Master of Data Science"
+  },
+  {
+    "code": "DATA401",
+    "name": "Time Series Forecasting",
+    "credits": 6,
+    "time": "Thursday 09:00–11:00",
+    "semester": "semester4",
+    "degree": "Master of Data Science"
+  },
+  {
+    "code": "DATA402",
+    "name": "Data Ethics",
+    "credits": 6,
+    "time": "Thursday 10:00–12:00",
+    "semester": "semester4",
+    "degree": "Master of Data Science"
+  },
+  {
+    "code": "DATA403",
+    "name": "Data Science Capstone",
+    "credits": 6,
+    "time": "Thursday 13:00–15:00",
+    "semester": "semester4",
+    "degree": "Master of Data Science"
+  },
+  {
+    "code": "DATA404",
+    "name": "Business Intelligence",
+    "credits": 6,
+    "time": "Thursday 14:00–16:00",
+    "semester": "semester4",
+    "degree": "Master of Data Science"
+  },
+  {
+    "code": "BUSA103",
+    "name": "Analytics Programming",
+    "credits": 6,
+    "time": "Monday 13:00–15:00",
+    "semester": "semester1",
+    "degree": "Master of Business Analytics"
+  },
+  {
+    "code": "BUSA104",
+    "name": "Business Statistics",
+    "credits": 6,
+    "time": "Monday 14:00–16:00",
+    "semester": "semester1",
+    "degree": "Master of Business Analytics"
+  },
   {
     "code": "BUSN5001",
     "name": "Business Analytics Foundations",
     "credits": 6,
     "time": "Monday 11:00–13:00",
     "semester": "semester1",
+    "degree": "Master of Business Analytics"
+  },
+  {
+    "code": "MKTG5502",
+    "name": "Marketing Analytics",
+    "credits": 6,
+    "time": "Thursday 10:00–12:00",
+    "semester": "semester1",
+    "degree": "Master of Business Analytics"
+  },
+  {
+    "code": "BUSA202",
+    "name": "Predictive Analytics",
+    "credits": 6,
+    "time": "Tuesday 10:00–12:00",
+    "semester": "semester2",
+    "degree": "Master of Business Analytics"
+  },
+  {
+    "code": "BUSA203",
+    "name": "Data Management",
+    "credits": 6,
+    "time": "Tuesday 13:00–15:00",
+    "semester": "semester2",
+    "degree": "Master of Business Analytics"
+  },
+  {
+    "code": "BUSA204",
+    "name": "Customer Analytics",
+    "credits": 6,
+    "time": "Tuesday 14:00–16:00",
+    "semester": "semester2",
     "degree": "Master of Business Analytics"
   },
   {
@@ -430,14 +1600,77 @@
     "degree": "Master of Business Analytics"
   },
   {
-    "code": "MKTG5502",
-    "name": "Marketing Analytics",
+    "code": "BUSA301",
+    "name": "Operations Analytics",
     "credits": 6,
-    "time": "Thursday 10:00–12:00",
-    "semester": "semester1",
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester3",
     "degree": "Master of Business Analytics"
   },
-
+  {
+    "code": "BUSA302",
+    "name": "Financial Analytics",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester3",
+    "degree": "Master of Business Analytics"
+  },
+  {
+    "code": "BUSA303",
+    "name": "Visual Analytics",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester3",
+    "degree": "Master of Business Analytics"
+  },
+  {
+    "code": "BUSA304",
+    "name": "Decision Modelling",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester3",
+    "degree": "Master of Business Analytics"
+  },
+  {
+    "code": "BUSA401",
+    "name": "Risk Analytics",
+    "credits": 6,
+    "time": "Thursday 09:00–11:00",
+    "semester": "semester4",
+    "degree": "Master of Business Analytics"
+  },
+  {
+    "code": "BUSA402",
+    "name": "Strategy and Analytics",
+    "credits": 6,
+    "time": "Thursday 10:00–12:00",
+    "semester": "semester4",
+    "degree": "Master of Business Analytics"
+  },
+  {
+    "code": "BUSA403",
+    "name": "Analytics Capstone",
+    "credits": 6,
+    "time": "Thursday 13:00–15:00",
+    "semester": "semester4",
+    "degree": "Master of Business Analytics"
+  },
+  {
+    "code": "BUSA404",
+    "name": "People Analytics",
+    "credits": 6,
+    "time": "Thursday 14:00–16:00",
+    "semester": "semester4",
+    "degree": "Master of Business Analytics"
+  },
+  {
+    "code": "ENGG5501",
+    "name": "Engineering Practice",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester1",
+    "degree": "Master of Professional Engineering"
+  },
   {
     "code": "GENG5507",
     "name": "Risk, Reliability and Safety",
@@ -447,10 +1680,18 @@
     "degree": "Master of Professional Engineering"
   },
   {
-    "code": "ENGG5501",
-    "name": "Engineering Practice",
+    "code": "MPE103",
+    "name": "Engineering Analysis",
     "credits": 6,
-    "time": "Wednesday 10:00–12:00",
+    "time": "Monday 13:00–15:00",
+    "semester": "semester1",
+    "degree": "Master of Professional Engineering"
+  },
+  {
+    "code": "MPE104",
+    "name": "Systems Safety",
+    "credits": 6,
+    "time": "Monday 14:00–16:00",
     "semester": "semester1",
     "degree": "Master of Professional Engineering"
   },
@@ -462,13 +1703,140 @@
     "semester": "semester2",
     "degree": "Master of Professional Engineering"
   },
-
+  {
+    "code": "MPE202",
+    "name": "Professional Practice",
+    "credits": 6,
+    "time": "Tuesday 10:00–12:00",
+    "semester": "semester2",
+    "degree": "Master of Professional Engineering"
+  },
+  {
+    "code": "MPE203",
+    "name": "Engineering Modelling",
+    "credits": 6,
+    "time": "Tuesday 13:00–15:00",
+    "semester": "semester2",
+    "degree": "Master of Professional Engineering"
+  },
+  {
+    "code": "MPE204",
+    "name": "Advanced Fluid Systems",
+    "credits": 6,
+    "time": "Tuesday 14:00–16:00",
+    "semester": "semester2",
+    "degree": "Master of Professional Engineering"
+  },
+  {
+    "code": "MPE301",
+    "name": "Project Management for Engineers",
+    "credits": 6,
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester3",
+    "degree": "Master of Professional Engineering"
+  },
+  {
+    "code": "MPE302",
+    "name": "Sustainable Engineering",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester3",
+    "degree": "Master of Professional Engineering"
+  },
+  {
+    "code": "MPE303",
+    "name": "Control and Automation",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester3",
+    "degree": "Master of Professional Engineering"
+  },
+  {
+    "code": "MPE304",
+    "name": "Advanced Materials",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester3",
+    "degree": "Master of Professional Engineering"
+  },
+  {
+    "code": "MPE401",
+    "name": "Infrastructure Planning",
+    "credits": 6,
+    "time": "Thursday 09:00–11:00",
+    "semester": "semester4",
+    "degree": "Master of Professional Engineering"
+  },
+  {
+    "code": "MPE402",
+    "name": "Energy Systems",
+    "credits": 6,
+    "time": "Thursday 10:00–12:00",
+    "semester": "semester4",
+    "degree": "Master of Professional Engineering"
+  },
+  {
+    "code": "MPE403",
+    "name": "Engineering Design Project",
+    "credits": 6,
+    "time": "Thursday 13:00–15:00",
+    "semester": "semester4",
+    "degree": "Master of Professional Engineering"
+  },
+  {
+    "code": "MPE404",
+    "name": "Research Methods for Engineers",
+    "credits": 6,
+    "time": "Thursday 14:00–16:00",
+    "semester": "semester4",
+    "degree": "Master of Professional Engineering"
+  },
+  {
+    "code": "STUD102",
+    "name": "Academic Communication",
+    "credits": 6,
+    "time": "Monday 10:00–12:00",
+    "semester": "semester1",
+    "degree": "Master of Studies"
+  },
+  {
+    "code": "STUD103",
+    "name": "Research Design",
+    "credits": 6,
+    "time": "Monday 13:00–15:00",
+    "semester": "semester1",
+    "degree": "Master of Studies"
+  },
+  {
+    "code": "STUD104",
+    "name": "Critical Inquiry",
+    "credits": 6,
+    "time": "Monday 14:00–16:00",
+    "semester": "semester1",
+    "degree": "Master of Studies"
+  },
   {
     "code": "STUD5001",
     "name": "Research Methods",
     "credits": 6,
     "time": "Monday 10:00–12:00",
     "semester": "semester1",
+    "degree": "Master of Studies"
+  },
+  {
+    "code": "STUD203",
+    "name": "Independent Study A",
+    "credits": 6,
+    "time": "Tuesday 13:00–15:00",
+    "semester": "semester2",
+    "degree": "Master of Studies"
+  },
+  {
+    "code": "STUD204",
+    "name": "Advanced Seminar",
+    "credits": 6,
+    "time": "Tuesday 14:00–16:00",
+    "semester": "semester2",
     "degree": "Master of Studies"
   },
   {
@@ -487,7 +1855,78 @@
     "semester": "semester2",
     "degree": "Master of Studies"
   },
-
+  {
+    "code": "STUD301",
+    "name": "Professional Practice",
+    "credits": 6,
+    "time": "Wednesday 09:00–11:00",
+    "semester": "semester3",
+    "degree": "Master of Studies"
+  },
+  {
+    "code": "STUD302",
+    "name": "Independent Study B",
+    "credits": 6,
+    "time": "Wednesday 10:00–12:00",
+    "semester": "semester3",
+    "degree": "Master of Studies"
+  },
+  {
+    "code": "STUD303",
+    "name": "Research Project",
+    "credits": 6,
+    "time": "Wednesday 13:00–15:00",
+    "semester": "semester3",
+    "degree": "Master of Studies"
+  },
+  {
+    "code": "STUD304",
+    "name": "Discipline Studies A",
+    "credits": 6,
+    "time": "Wednesday 14:00–16:00",
+    "semester": "semester3",
+    "degree": "Master of Studies"
+  },
+  {
+    "code": "STUD401",
+    "name": "Discipline Studies B",
+    "credits": 6,
+    "time": "Thursday 09:00–11:00",
+    "semester": "semester4",
+    "degree": "Master of Studies"
+  },
+  {
+    "code": "STUD402",
+    "name": "Advanced Project",
+    "credits": 6,
+    "time": "Thursday 10:00–12:00",
+    "semester": "semester4",
+    "degree": "Master of Studies"
+  },
+  {
+    "code": "STUD403",
+    "name": "Studies Capstone",
+    "credits": 6,
+    "time": "Thursday 13:00–15:00",
+    "semester": "semester4",
+    "degree": "Master of Studies"
+  },
+  {
+    "code": "STUD404",
+    "name": "Interdisciplinary Methods",
+    "credits": 6,
+    "time": "Thursday 14:00–16:00",
+    "semester": "semester4",
+    "degree": "Master of Studies"
+  },
+  {
+    "code": "HPEA102",
+    "name": "Simulation in Health Education",
+    "credits": 6,
+    "time": "Monday 10:00–12:00",
+    "semester": "semester1",
+    "degree": "Graduate Diploma in Health Professions Education"
+  },
   {
     "code": "HPEA5101",
     "name": "Teaching and Learning in Health",
@@ -512,7 +1951,14 @@
     "semester": "semester2",
     "degree": "Graduate Diploma in Health Professions Education"
   },
-
+  {
+    "code": "IDIS102",
+    "name": "Antimicrobial Stewardship",
+    "credits": 6,
+    "time": "Monday 10:00–12:00",
+    "semester": "semester1",
+    "degree": "Graduate Diploma in Infectious Diseases"
+  },
   {
     "code": "MICR5001",
     "name": "Medical Microbiology",
@@ -537,7 +1983,14 @@
     "semester": "semester2",
     "degree": "Graduate Diploma in Infectious Diseases"
   },
-
+  {
+    "code": "ENVT102",
+    "name": "Environmental Monitoring",
+    "credits": 6,
+    "time": "Monday 10:00–12:00",
+    "semester": "semester1",
+    "degree": "Graduate Diploma in Environmental Science"
+  },
   {
     "code": "ENVT4401",
     "name": "Environmental Impact Assessment",
@@ -562,13 +2015,28 @@
     "semester": "semester2",
     "degree": "Graduate Diploma in Environmental Science"
   },
-
   {
     "code": "BUSN5101",
     "name": "Business Foundations",
     "credits": 6,
     "time": "Monday 13:00–15:00",
     "semester": "semester1",
+    "degree": "Graduate Diploma in Business"
+  },
+  {
+    "code": "ECON5503",
+    "name": "Economic Management",
+    "credits": 6,
+    "time": "Thursday 12:00–14:00",
+    "semester": "semester1",
+    "degree": "Graduate Diploma in Business"
+  },
+  {
+    "code": "BUSG202",
+    "name": "Accounting for Managers",
+    "credits": 6,
+    "time": "Tuesday 10:00–12:00",
+    "semester": "semester2",
     "degree": "Graduate Diploma in Business"
   },
   {
@@ -580,28 +2048,11 @@
     "degree": "Graduate Diploma in Business"
   },
   {
-    "code": "ECON5503",
-    "name": "Economic Management",
-    "credits": 6,
-    "time": "Thursday 12:00–14:00",
-    "semester": "semester1",
-    "degree": "Graduate Diploma in Business"
-  },
-
-  {
     "code": "EDUC5501",
     "name": "Teaching and Learning",
     "credits": 6,
     "time": "Monday 09:00–11:00",
     "semester": "semester1",
-    "degree": "Graduate Diploma in Education"
-  },
-  {
-    "code": "EDUC5502",
-    "name": "Classroom Practice",
-    "credits": 6,
-    "time": "Wednesday 11:00–13:00",
-    "semester": "semester2",
     "degree": "Graduate Diploma in Education"
   },
   {
@@ -611,6 +2062,21 @@
     "time": "Friday 14:00–16:00",
     "semester": "semester1",
     "degree": "Graduate Diploma in Education"
+  },
+  {
+    "code": "EDUC202",
+    "name": "Educational Psychology",
+    "credits": 6,
+    "time": "Tuesday 10:00–12:00",
+    "semester": "semester2",
+    "degree": "Graduate Diploma in Education"
+  },
+  {
+    "code": "EDUC5502",
+    "name": "Classroom Practice",
+    "credits": 6,
+    "time": "Wednesday 11:00–13:00",
+    "semester": "semester2",
+    "degree": "Graduate Diploma in Education"
   }
-
 ]

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -697,13 +697,50 @@ function selectDegree(shouldResetCourses = true) {
     displayAvailableCourses(selectedDegree);
 }
 
+function updateSemesterFilter(courses) {
+    const semesterFilter = document.getElementById("semester-filter");
+
+    if (!semesterFilter) {
+        return;
+    }
+
+    semesterFilter.innerHTML = "";
+
+    const allOption = document.createElement("option");
+    allOption.value = "all";
+    allOption.textContent = "All Semesters";
+    semesterFilter.appendChild(allOption);
+
+    const semesters = [...new Set(courses.map(function (course) {
+        return course.semester;
+    }))];
+
+    semesters.sort(function (a, b) {
+        const numberA = parseInt(a.replace(/\D/g, ""));
+        const numberB = parseInt(b.replace(/\D/g, ""));
+        return numberA - numberB;
+    });
+
+    semesters.forEach(function (semester) {
+        const option = document.createElement("option");
+        option.value = semester;
+        option.textContent = "Semester " + semester.replace(/\D/g, "");
+        semesterFilter.appendChild(option);
+    });
+}
+
 function displayAvailableCourses(degreeName) {
     const availableCoursesBox = document.getElementById("available-courses");
     if (!availableCoursesBox) return;
 
     const courses = courseOptions[degreeName];
 
+    if (courses) {
+    updateSemesterFilter(courses);
+}
+
     if (!courses || courses.length === 0) {
+        
         availableCoursesBox.innerHTML = `
             <div class="empty-course-state">
                 <p>${t("Please select a study level and degree to view available courses.")}</p>


### PR DESCRIPTION
## Summary

This PR expands the course dataset to better support realistic study planning across different study levels.

## Changes Made

- Added more course data for Bachelor degrees
- Added more course data for Master degrees
- Added more course data for Diploma programs
- Improved semester coverage for course filtering and timetable planning
- Updated course data to better match the expected dataset structure

## Testing

Tested manually by:

- Opening the Course Selection page
- Selecting different study levels and degrees
- Checking that courses appear for the selected degree
- Checking semester filtering with the expanded course data

## Related Issue

Closes #101