### PR TITLE
Implement semester progression workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,6 @@ from werkzeug.security import check_password_hash, generate_password_hash
 app = Flask(__name__)
 
 app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "temporary-development-secret-key")
-
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///course_planner.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
@@ -42,6 +41,7 @@ app.config["MAIL_PASSWORD"] = 'kkna wewv svyg xcwo'
 app.config["MAIL_DEFAULT_SENDER"] = "kumar.aneesh71098@gmail.com"
 
 mail = Mail(app)
+
 
 def get_locale():
     return session.get("language", "en")
@@ -63,6 +63,7 @@ login_manager.login_message_category = "error"
 # ---------------------------------------------------------------------------
 
 class Admin(UserMixin, db.Model):
+    """Separate admin accounts — completely independent from student User records."""
     id = db.Column(db.Integer, primary_key=True)
     full_name = db.Column(db.String(100), nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
@@ -73,6 +74,7 @@ class Admin(UserMixin, db.Model):
 
 
 class User(UserMixin, db.Model):
+    """Student accounts only."""
     id = db.Column(db.Integer, primary_key=True)
     full_name = db.Column(db.String(100), nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
@@ -80,11 +82,29 @@ class User(UserMixin, db.Model):
     password_hash = db.Column(db.String(255), nullable=False)
     selected_degree = db.Column(db.String(120), nullable=True)
     enrollment_status = db.Column(db.String(20), default="planning")
+    # Values: 'planning' | 'enrolled' | 'change_requested'
     reset_code = db.Column(db.String(4), nullable=True)
     reset_code_expires_at = db.Column(db.DateTime, nullable=True)
 
     def get_id(self):
         return f"u_{self.id}"
+
+
+class SemesterPass(db.Model):
+    """
+    Records that a student has passed a specific semester for a degree.
+    Created by admin via POST /api/admin/mark-semester-passed/<user_id>.
+
+    Semester 1 is open by default (no pass record needed).
+    To enrol in Semester N, the student must have a SemesterPass for Semester N-1.
+    """
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    degree = db.Column(db.String(120), nullable=False)
+    semester_number = db.Column(db.Integer, nullable=False)
+    passed_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    user = db.relationship("User", backref="semester_passes")
 
 
 class EnrollmentChangeRequest(db.Model):
@@ -93,6 +113,7 @@ class EnrollmentChangeRequest(db.Model):
     requested_degree = db.Column(db.String(120), nullable=False)
     requested_course_codes = db.Column(db.Text, nullable=False)
     status = db.Column(db.String(20), default="pending")
+    # Values: 'pending' | 'approved' | 'rejected'
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     reviewed_at = db.Column(db.DateTime, nullable=True)
 
@@ -117,6 +138,135 @@ class Selection(db.Model):
     user = db.relationship("User", backref="selections")
     course = db.relationship("Course", backref="selections")
 
+
+# ---------------------------------------------------------------------------
+# Semester progression helpers
+# ---------------------------------------------------------------------------
+
+def semester_key_to_number(semester_key):
+    """Converts values like 'semester1' or 'Semester 1' into integer 1."""
+    if semester_key is None:
+        return None
+
+    match = re.search(r"\d+", str(semester_key))
+    return int(match.group()) if match else None
+
+
+def get_passed_semester_numbers_for_degree(user, degree):
+    """Returns sorted passed semester numbers for this exact user + degree."""
+    if not user or not degree:
+        return []
+
+    passes = SemesterPass.query.filter_by(
+        user_id=user.id,
+        degree=degree,
+    ).all()
+
+    return sorted({p.semester_number for p in passes})
+
+
+def get_eligible_semester_number_for_degree(user, degree):
+    """
+    Returns the semester number the student is eligible to enrol in for the
+    requested degree.
+
+    Important:
+    We pass degree into this function instead of always using
+    user.selected_degree. This prevents students from bypassing semester rules
+    by submitting courses for another degree.
+    """
+    passed = get_passed_semester_numbers_for_degree(user, degree)
+    return (max(passed) + 1) if passed else 1
+
+
+def get_eligible_semester_number(user):
+    """Returns eligibility for the user's currently stored selected degree."""
+    return get_eligible_semester_number_for_degree(user, user.selected_degree)
+
+
+def get_passed_semester_numbers(user):
+    """Returns passed semesters for the user's currently stored selected degree."""
+    return get_passed_semester_numbers_for_degree(user, user.selected_degree)
+
+
+def validate_semester_selection(
+    user,
+    requested_degree,
+    course_codes,
+    allow_empty=False,
+    allow_degree_change=False,
+):
+    """
+    Central backend enforcement for semester progression.
+
+    Rules enforced here:
+      - degree is required when courses are being saved/confirmed
+      - course codes must exist
+      - courses must belong to the requested degree
+      - all selected courses must be from one semester only
+      - selected semester must equal the eligible semester for the requested degree
+      - after a pass exists in the current degree, direct degree switching is blocked
+    """
+    requested_degree = (requested_degree or "").strip()
+    course_codes = course_codes or []
+
+    if not requested_degree:
+        return None, "Please select a degree before saving courses."
+
+    if not course_codes and not allow_empty:
+        return None, "Please select at least one course."
+
+    current_degree = user.selected_degree or ""
+    current_degree_passes = get_passed_semester_numbers_for_degree(user, current_degree)
+
+    if (
+        current_degree
+        and requested_degree != current_degree
+        and current_degree_passes
+        and not allow_degree_change
+    ):
+        return None, (
+            "Your degree is locked because you have already passed at least one semester. "
+            "Please use the change request flow for admin approval."
+        )
+
+    eligible_semester = get_eligible_semester_number_for_degree(user, requested_degree)
+    passed_semesters = get_passed_semester_numbers_for_degree(user, requested_degree)
+
+    selected_semesters = set()
+    valid_courses = []
+
+    for code in course_codes:
+        course = Course.query.filter_by(code=code).first()
+
+        if not course:
+            return None, f"Course {code} was not found."
+
+        if course.degree != requested_degree:
+            return None, f"Course {course.code} does not belong to {requested_degree}."
+
+        semester_number = semester_key_to_number(course.semester)
+
+        if semester_number in passed_semesters:
+            return None, f"Semester {semester_number} has already been passed."
+
+        if semester_number != eligible_semester:
+            return None, (
+                f"Semester {semester_number} is locked. "
+                f"You are currently eligible to enrol in Semester {eligible_semester}."
+            )
+
+        selected_semesters.add(semester_number)
+        valid_courses.append(course)
+
+    if len(selected_semesters) > 1:
+        return None, "Please select courses from one semester only."
+
+    return {
+        "courses": valid_courses,
+        "eligible_semester": eligible_semester,
+        "passed_semesters": passed_semesters,
+    }, None
 
 # ---------------------------------------------------------------------------
 # Seed
@@ -170,17 +320,14 @@ def seed_admin():
 def load_user(user_id):
     if str(user_id).startswith("a_"):
         return Admin.query.get(int(user_id[2:]))
-
     if str(user_id).startswith("u_"):
         return User.query.get(int(user_id[2:]))
-
     return User.query.get(int(user_id))
 
 
 def is_admin_user(user):
     if not user.is_authenticated:
         return False
-
     return isinstance(user, Admin)
 
 
@@ -191,9 +338,7 @@ def admin_required(view_function):
         if not is_admin_user(current_user):
             flash(gettext("You do not have permission to access the admin dashboard."), "error")
             return redirect(url_for("homepage"))
-
         return view_function(*args, **kwargs)
-
     return wrapped_view
 
 
@@ -203,9 +348,7 @@ def student_required(view_function):
     def wrapped_view(*args, **kwargs):
         if is_admin_user(current_user):
             return redirect(url_for("admin_dashboard"))
-
         return view_function(*args, **kwargs)
-
     return wrapped_view
 
 
@@ -224,7 +367,6 @@ def inject_admin_status():
 def set_language(language):
     if language in app.config["LANGUAGES"]:
         session["language"] = language
-
     return redirect(request.referrer or url_for("index"))
 
 
@@ -374,7 +516,6 @@ def timetable():
 @student_required
 def api_courses():
     courses = Course.query.all()
-
     return {
         "courses": [
             {
@@ -397,12 +538,26 @@ def api_selected_courses():
     selections = Selection.query.filter_by(user_id=current_user.id).all()
 
     selected_degree = current_user.selected_degree or ""
+
     if not selected_degree and selections:
         selected_degree = selections[0].course.degree
 
+    eligible_semester = get_eligible_semester_number_for_degree(
+        current_user,
+        selected_degree,
+    )
+
+    passed_semesters = get_passed_semester_numbers_for_degree(
+        current_user,
+        selected_degree,
+    )
+
     return {
         "degree": selected_degree,
+        "degree_locked": bool(selected_degree and passed_semesters),
         "enrollment_status": current_user.enrollment_status or "planning",
+        "eligible_semester": eligible_semester,
+        "passed_semesters": passed_semesters,
         "courses": [
             {
                 "code": s.course.code,
@@ -425,22 +580,40 @@ def save_selection():
         return {"error": "Already enrolled. Submit a change request to make changes."}, 403
 
     data = request.get_json() or {}
+
     course_codes = data.get("courses", [])
-    degree = data.get("degree", "")
+    requested_degree = data.get("degree", "")
+
+    validation, error = validate_semester_selection(
+        current_user,
+        requested_degree,
+        course_codes,
+        allow_empty=True,
+        allow_degree_change=False,
+    )
+
+    if error:
+        return {"error": error}, 403
 
     Selection.query.filter_by(user_id=current_user.id).delete()
 
-    for code in course_codes:
-        course = Course.query.filter_by(code=code).first()
-        if course:
-            db.session.add(Selection(user_id=current_user.id, course_id=course.id))
+    for course in validation["courses"]:
+        db.session.add(
+            Selection(
+                user_id=current_user.id,
+                course_id=course.id,
+            )
+        )
 
-    if degree:
-        current_user.selected_degree = degree
+    current_user.selected_degree = requested_degree
 
     db.session.commit()
 
-    return {"message": "Selection saved."}
+    return {
+        "message": "Selection saved.",
+        "eligible_semester": validation["eligible_semester"],
+        "passed_semesters": validation["passed_semesters"],
+    }
 
 
 @app.route("/api/confirm-enrollment", methods=["POST"])
@@ -452,18 +625,51 @@ def confirm_enrollment():
     if current_user.enrollment_status == "change_requested":
         return {"error": "A change request is already pending approval."}, 400
 
-    selections = Selection.query.filter_by(user_id=current_user.id).count()
+    data = request.get_json(silent=True) or {}
 
-    if selections == 0:
-        return {"error": "Please select at least one course before confirming enrollment."}, 400
+    requested_degree = (
+        data.get("degree")
+        or current_user.selected_degree
+        or ""
+    ).strip()
 
-    if not current_user.selected_degree:
-        return {"error": "Please select a degree before confirming enrollment."}, 400
+    submitted_codes = data.get("courses")
 
+    if submitted_codes is None:
+        selections = Selection.query.filter_by(user_id=current_user.id).all()
+        submitted_codes = [selection.course.code for selection in selections]
+
+    validation, error = validate_semester_selection(
+        current_user,
+        requested_degree,
+        submitted_codes,
+        allow_empty=False,
+        allow_degree_change=False,
+    )
+
+    if error:
+        return {"error": error}, 403
+
+    Selection.query.filter_by(user_id=current_user.id).delete()
+
+    for course in validation["courses"]:
+        db.session.add(
+            Selection(
+                user_id=current_user.id,
+                course_id=course.id,
+            )
+        )
+
+    current_user.selected_degree = requested_degree
     current_user.enrollment_status = "enrolled"
+
     db.session.commit()
 
-    return {"message": "Enrollment confirmed! Changes now require admin approval."}
+    return {
+        "message": "Enrollment confirmed! Changes now require admin approval.",
+        "eligible_semester": validation["eligible_semester"],
+        "passed_semesters": validation["passed_semesters"],
+    }
 
 
 @app.route("/api/request-change", methods=["POST"])
@@ -481,16 +687,27 @@ def request_change():
         return {"error": "You already have a pending change request."}, 400
 
     data = request.get_json() or {}
+
     requested_degree = data.get("degree", "")
     requested_courses = data.get("courses", [])
 
-    if not requested_degree or not requested_courses:
-        return {"error": "Please include a degree and at least one course in your request."}, 400
+    validation, error = validate_semester_selection(
+        current_user,
+        requested_degree,
+        requested_courses,
+        allow_empty=False,
+        allow_degree_change=True,
+    )
+
+    if error:
+        return {"error": error}, 403
 
     change_req = EnrollmentChangeRequest(
         user_id=current_user.id,
         requested_degree=requested_degree,
-        requested_course_codes=json.dumps(requested_courses),
+        requested_course_codes=json.dumps(
+            [course.code for course in validation["courses"]]
+        ),
     )
 
     current_user.enrollment_status = "change_requested"
@@ -509,14 +726,30 @@ def request_change():
 @admin_required
 def approve_change(request_id):
     req = EnrollmentChangeRequest.query.get_or_404(request_id)
-    user = User.query.get(req.user_id)
+    user = User.query.get_or_404(req.user_id)
+
+    requested_courses = json.loads(req.requested_course_codes)
+
+    validation, error = validate_semester_selection(
+        user,
+        req.requested_degree,
+        requested_courses,
+        allow_empty=False,
+        allow_degree_change=True,
+    )
+
+    if error:
+        return {"error": error}, 403
 
     Selection.query.filter_by(user_id=user.id).delete()
 
-    for code in json.loads(req.requested_course_codes):
-        course = Course.query.filter_by(code=code).first()
-        if course:
-            db.session.add(Selection(user_id=user.id, course_id=course.id))
+    for course in validation["courses"]:
+        db.session.add(
+            Selection(
+                user_id=user.id,
+                course_id=course.id,
+            )
+        )
 
     user.selected_degree = req.requested_degree
     user.enrollment_status = "enrolled"
@@ -539,8 +772,95 @@ def reject_change(request_id):
     req.reviewed_at = datetime.utcnow()
 
     db.session.commit()
-
     return {"message": "Change request rejected."}
+
+
+# ---------------------------------------------------------------------------
+# Admin API — semester progression
+# ---------------------------------------------------------------------------
+
+@app.route("/api/admin/mark-semester-passed/<int:user_id>", methods=["POST"])
+@admin_required
+def mark_semester_passed(user_id):
+    """
+    Admin marks the currently enrolled semester as passed.
+
+    Effects:
+      - creates SemesterPass(user_id, degree, semester_number)
+      - clears current Selection rows
+      - resets enrollment_status to planning
+      - preserves selected_degree so the student's degree remains pre-selected
+    """
+    user = User.query.get_or_404(user_id)
+
+    data = request.get_json() or {}
+    semester_number = data.get("semester_number")
+
+    if not user.selected_degree:
+        return {"error": "Student has not selected a degree yet."}, 400
+
+    if user.enrollment_status != "enrolled":
+        return {
+            "error": "Student must be enrolled before a semester can be marked as passed."
+        }, 400
+
+    selections = Selection.query.filter_by(user_id=user.id).all()
+
+    if not selections:
+        return {"error": "Student has no enrolled course selections to pass."}, 400
+
+    enrolled_semesters = {
+        semester_key_to_number(selection.course.semester)
+        for selection in selections
+    }
+
+    if len(enrolled_semesters) != 1:
+        return {
+            "error": "Student selections must belong to one semester before marking passed."
+        }, 400
+
+    enrolled_semester = enrolled_semesters.pop()
+
+    if semester_number is not None and int(semester_number) != enrolled_semester:
+        return {
+            "error": f"Student is enrolled in Semester {enrolled_semester}, not Semester {semester_number}."
+        }, 400
+
+    existing = SemesterPass.query.filter_by(
+        user_id=user.id,
+        degree=user.selected_degree,
+        semester_number=enrolled_semester,
+    ).first()
+
+    if existing:
+        return {
+            "error": f"Semester {enrolled_semester} is already marked as passed for this student."
+        }, 400
+
+    semester_pass = SemesterPass(
+        user_id=user.id,
+        degree=user.selected_degree,
+        semester_number=enrolled_semester,
+    )
+
+    db.session.add(semester_pass)
+
+    Selection.query.filter_by(user_id=user.id).delete()
+
+    user.enrollment_status = "planning"
+
+    db.session.commit()
+
+    next_semester = enrolled_semester + 1
+
+    return {
+        "message": (
+            f"Semester {enrolled_semester} marked as passed for {user.full_name}. "
+            f"They are now eligible to enrol in Semester {next_semester}."
+        ),
+        "passed_semester": enrolled_semester,
+        "next_eligible_semester": next_semester,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -555,6 +875,15 @@ def api_admin_enrollments():
 
     for user in users:
         selections = Selection.query.filter_by(user_id=user.id).all()
+        eligible_semester = get_eligible_semester_number(user)
+        passed_semesters = get_passed_semester_numbers(user)
+
+        selected_semesters = sorted({
+            semester_key_to_number(s.course.semester)
+            for s in selections
+        })
+
+        enrolled_semester = selected_semesters[0] if len(selected_semesters) == 1 else None
 
         result.append({
             "id": user.id,
@@ -564,6 +893,9 @@ def api_admin_enrollments():
             "enrollment_status": user.enrollment_status or "planning",
             "selected_degree": user.selected_degree or "N/A",
             "course_count": len(selections),
+            "eligible_semester": eligible_semester,
+            "enrolled_semester": enrolled_semester,
+            "passed_semesters": passed_semesters,
             "courses": [
                 {
                     "code": s.course.code,
@@ -647,7 +979,6 @@ def api_admin_edit_course(course_id):
     course.degree = data.get("degree", course.degree)
 
     db.session.commit()
-
     return {"message": "Course updated successfully."}
 
 
@@ -812,7 +1143,6 @@ def reset_password_with_code():
         user.reset_code = None
         user.reset_code_expires_at = None
         db.session.commit()
-
         return {"error": "Verification code expired. Please request a new code."}, 400
 
     if user.reset_code != code:

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -226,6 +226,11 @@ function showDashboardMessage(message) {
  */
 let enrollmentStatus = "planning";
 let isEditingChangeRequest = false;
+let eligibleSemester = 1;
+let passedSemesters = [];
+let degreeLocked = false;
+let backendStateLoaded = false;
+let catalogueLoaded = false;
 
 // Snapshot of the enrolled selection so we can cancel a change draft.
 let enrolledCoursesSnapshot = [];
@@ -254,33 +259,56 @@ function saveSelectedCourses() {
 // ---------------------------------------------------------------------------
 
 function saveSelectedCoursesToBackend() {
-    // Never auto-save if locked and not in a change-request draft.
     if ((enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
         && !isEditingChangeRequest) {
-        return;
+        return Promise.resolve();
     }
 
     const degree = localStorage.getItem("selectedDegree") || "";
     const courseCodes = selectedCourses.map(c => c.code);
 
-    fetch("/api/save-selection", {
+    return fetch("/api/save-selection", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ courses: courseCodes, degree: degree }),
+        body: JSON.stringify({
+            courses: courseCodes,
+            degree: degree,
+        }),
     })
         .then(function (response) {
-            if (!response.ok) {
-                return response.json().then(function (d) {
-                    throw new Error(d.error || "Save failed.");
-                });
-            }
-            return response.json();
+            return response.json().then(function (data) {
+                if (!response.ok) {
+                    throw new Error(data.error || "Save failed.");
+                }
+
+                return data;
+            });
         })
         .then(function (data) {
+            if (typeof data.eligible_semester !== "undefined") {
+                eligibleSemester = data.eligible_semester;
+            }
+
+            if (Array.isArray(data.passed_semesters)) {
+                passedSemesters = data.passed_semesters;
+            }
+
+            degreeLocked = passedSemesters.length > 0;
+
+            updateSemesterEligibilityBanner();
+            applyDegreeLockState();
+
             console.log("Draft saved:", data.message);
+
+            return data;
         })
         .catch(function (error) {
             console.log("Save failed:", error);
+
+            const msg = document.getElementById("course-message");
+            if (msg) msg.textContent = error.message;
+
+            throw error;
         });
 }
 
@@ -289,28 +317,29 @@ function saveSelectedCoursesToBackend() {
 // ---------------------------------------------------------------------------
 
 function loadSelectedCoursesFromBackend() {
-    fetch("/api/selected-courses")
+    return fetch("/api/selected-courses")
         .then(r => r.json())
         .then(function (data) {
+            backendStateLoaded = true;
+
             enrollmentStatus = data.enrollment_status || "planning";
             selectedCourses = data.courses || [];
+            eligibleSemester = data.eligible_semester || 1;
+            passedSemesters = data.passed_semesters || [];
+            degreeLocked = !!data.degree_locked || passedSemesters.length > 0;
 
-            localStorage.setItem(SELECTED_COURSES_STORAGE_KEY, JSON.stringify(selectedCourses));
+            localStorage.setItem(
+                SELECTED_COURSES_STORAGE_KEY,
+                JSON.stringify(selectedCourses)
+            );
 
-            if (selectedCourses.length > 0 && data.degree) {
+            if (data.degree) {
                 const studyLevel = getStudyLevelByDegree(data.degree);
+
                 localStorage.setItem("selectedDegree", data.degree);
                 localStorage.setItem("selectedStudyLevel", studyLevel);
 
-                const studyLevelSelect = document.getElementById("study-level-select");
-                const degreeSelect = document.getElementById("degree-select");
-
-                if (studyLevelSelect && degreeSelect) {
-                    studyLevelSelect.value = studyLevel;
-                    updateDegreeOptions(false);
-                    degreeSelect.value = data.degree;
-                    selectDegree(false);
-                }
+                setDegreeControlsFromState(studyLevel, data.degree);
             } else {
                 localStorage.removeItem("selectedDegree");
                 localStorage.removeItem("selectedStudyLevel");
@@ -320,15 +349,23 @@ function loadSelectedCoursesFromBackend() {
             displaySelectedCourses();
             loadDashboardStats();
             loadTimetablePage();
+            updateSemesterEligibilityBanner();
+            applyDegreeLockState();
 
-            // Lock the UI if the student is already enrolled or has a pending request.
             if (enrollmentStatus !== "planning") {
                 lockEnrollmentUI(enrollmentStatus);
             } else {
-                // Make sure the confirm button is visible in planning mode.
                 const confirmBtn = document.getElementById("confirm-enrollment-btn");
                 if (confirmBtn) confirmBtn.style.display = "block";
             }
+
+            const currentDegree = localStorage.getItem("selectedDegree") || "";
+
+            if (catalogueLoaded && currentDegree) {
+                displayAvailableCourses(currentDegree);
+            }
+
+            return data;
         })
         .catch(function (error) {
             console.log("Could not load selected courses:", error);
@@ -340,10 +377,11 @@ function loadSelectedCoursesFromBackend() {
 // ---------------------------------------------------------------------------
 
 function loadCoursesFromBackend() {
-    fetch("/api/courses")
+    return fetch("/api/courses")
         .then(r => r.json())
         .then(function (data) {
             courseOptions = {};
+            
             data.courses.forEach(function (course) {
                 if (!courseOptions[course.degree]) courseOptions[course.degree] = [];
                 courseOptions[course.degree].push({
@@ -356,7 +394,10 @@ function loadCoursesFromBackend() {
                     semester: course.semester,
                 });
             });
+
+            catalogueLoaded = true;
             restoreCourseSelectionForm();
+            return data;
         })
         .catch(err => console.log("Courses could not be loaded:", err));
 }
@@ -396,6 +437,120 @@ function getStudyLevelByDegree(degreeName) {
         if (degreeOptions[level].includes(degreeName)) return level;
     }
     return "";
+}
+
+function setDegreeControlsFromState(studyLevel, degree) {
+    const studyLevelSelect = document.getElementById("study-level-select");
+    const degreeSelect = document.getElementById("degree-select");
+    const degreeSummary = document.getElementById("degree-summary");
+    const studyLevelSummary = document.getElementById("study-level-summary");
+    const courseMessage = document.getElementById("course-message");
+
+    if (!studyLevelSelect || !degreeSelect) return;
+
+    studyLevelSelect.value = studyLevel || "";
+
+    rebuildDegreeOptions(studyLevel || "", degree || "");
+
+    degreeSelect.value = degree || "";
+
+    if (degreeSummary) {
+        degreeSummary.textContent = degree || t("Not selected");
+    }
+
+    if (studyLevelSummary) {
+        const selectedOption = studyLevelSelect.options[studyLevelSelect.selectedIndex];
+        studyLevelSummary.textContent = selectedOption
+            ? selectedOption.text
+            : t("Not selected");
+    }
+
+    if (courseMessage && degree) {
+        courseMessage.textContent =
+            degree + " selected. You can now add courses to your eligible semester.";
+    }
+}
+
+
+function rebuildDegreeOptions(selectedLevel, selectedDegree) {
+    const degreeSelect = document.getElementById("degree-select");
+
+    if (!degreeSelect) return;
+
+    degreeSelect.innerHTML = "";
+
+    if (!selectedLevel) {
+        const defaultOption = document.createElement("option");
+        defaultOption.value = "";
+        defaultOption.textContent = t("-- Select a study level first --");
+
+        degreeSelect.appendChild(defaultOption);
+        degreeSelect.disabled = true;
+
+        return;
+    }
+
+    const placeholderOption = document.createElement("option");
+    placeholderOption.value = "";
+    placeholderOption.textContent = t("-- Select a degree --");
+
+    degreeSelect.appendChild(placeholderOption);
+
+    (degreeOptions[selectedLevel] || []).forEach(function (degreeName) {
+        const option = document.createElement("option");
+        option.value = degreeName;
+        option.textContent = t(degreeName);
+
+        degreeSelect.appendChild(option);
+    });
+
+    if (selectedDegree) {
+        degreeSelect.value = selectedDegree;
+    }
+
+    degreeSelect.disabled = false;
+}
+
+
+function applyDegreeLockState() {
+    const studyLevelSelect = document.getElementById("study-level-select");
+    const degreeSelect = document.getElementById("degree-select");
+
+    const shouldLockDegree =
+        ((enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested") && !isEditingChangeRequest)
+        || (degreeLocked && !isEditingChangeRequest);
+
+    if (studyLevelSelect) {
+        studyLevelSelect.disabled = shouldLockDegree;
+    }
+
+    if (degreeSelect) {
+        degreeSelect.disabled =
+            shouldLockDegree
+            || !studyLevelSelect
+            || !studyLevelSelect.value;
+    }
+}
+
+
+function getSemesterNumber(semesterKey) {
+    const match = String(semesterKey || "").match(/\d+/);
+    return match ? parseInt(match[0], 10) : null;
+}
+
+
+function getCourseSemesterState(course) {
+    const sem = getSemesterNumber(course.semester);
+
+    if (passedSemesters.includes(sem)) {
+        return "passed";
+    }
+
+    if (sem !== eligibleSemester) {
+        return "locked";
+    }
+
+    return "eligible";
 }
 
 // ---------------------------------------------------------------------------
@@ -458,16 +613,25 @@ function lockEnrollmentUI(status) {
  * kept separate from the confirmed enrollment until the request is submitted.
  */
 function unlockForChangeRequest() {
+    const currentDegree = localStorage.getItem("selectedDegree") || "";
+    const currentStudyLevel =
+        localStorage.getItem("selectedStudyLevel") || getStudyLevelByDegree(currentDegree);
+
     const studyLevelSelect = document.getElementById("study-level-select");
     const degreeSelect = document.getElementById("degree-select");
+
     if (studyLevelSelect) studyLevelSelect.disabled = false;
     if (degreeSelect) degreeSelect.disabled = false;
 
-    // Re-enable Add buttons for the currently displayed degree
-    const currentDegree = localStorage.getItem("selectedDegree") || "";
-    if (currentDegree) displayAvailableCourses(currentDegree);
+    if (currentStudyLevel) {
+        setDegreeControlsFromState(currentStudyLevel, currentDegree);
+    }
 
-    displaySelectedCourses(); // re-renders with Remove buttons
+    if (currentDegree) {
+        displayAvailableCourses(currentDegree);
+    }
+
+    displaySelectedCourses();
 }
 
 // ---------------------------------------------------------------------------
@@ -479,46 +643,70 @@ function confirmEnrollment() {
         alert(t("Please select at least one course before confirming enrollment."));
         return;
     }
+
     const degree = localStorage.getItem("selectedDegree") || "";
+
     if (!degree) {
         alert(t("Please select a degree before confirming enrollment."));
         return;
     }
+
+    const invalidCourse = selectedCourses.find(function (course) {
+        return getCourseSemesterState(course) !== "eligible";
+    });
+
+    if (invalidCourse) {
+        alert("You can only confirm Semester " + eligibleSemester + " courses.");
+        return;
+    }
+
     if (!confirm(t("Confirm your enrollment? After confirming, any changes will require admin approval."))) {
         return;
     }
 
-    // Save the current draft first, then confirm.
     const courseCodes = selectedCourses.map(c => c.code);
-    fetch("/api/save-selection", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ courses: courseCodes, degree: degree }),
-    })
-        .then(r => r.json())
+
+    saveSelectedCoursesToBackend()
         .then(function () {
             return fetch("/api/confirm-enrollment", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    courses: courseCodes,
+                    degree: degree,
+                }),
             });
         })
-        .then(r => r.json())
+        .then(function (response) {
+            return response.json().then(function (data) {
+                if (!response.ok) {
+                    throw new Error(data.error || "Confirm enrollment failed.");
+                }
+
+                return data;
+            });
+        })
         .then(function (data) {
-            if (data.error) {
-                alert(data.error);
-                return;
-            }
             enrollmentStatus = "enrolled";
 
-            const confirmedSemester = parseInt(selectedCourses[0].semester.replace("semester", ""), 10);
-            localStorage.setItem("completedSemester", confirmedSemester);
+            if (typeof data.eligible_semester !== "undefined") {
+                eligibleSemester = data.eligible_semester;
+            }
+
+            if (Array.isArray(data.passed_semesters)) {
+                passedSemesters = data.passed_semesters;
+            }
+
+            degreeLocked = passedSemesters.length > 0;
 
             lockEnrollmentUI("enrolled");
+            updateSemesterEligibilityBanner();
+
             alert(t("Enrollment confirmed successfully!"));
         })
         .catch(function (err) {
             console.log("Confirm enrollment failed:", err);
-            alert(t("Something went wrong. Please try again."));
+            alert(err.message || t("Something went wrong. Please try again."));
         });
 }
 
@@ -636,12 +824,6 @@ function submitChangeRequest() {
 // Degree / course UI
 
 function updateDegreeOptions(shouldResetCourses = true) {
-    // Locked while enrolled and not in a change-request draft
-    if ((enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
-        && !isEditingChangeRequest) {
-        return;
-    }
-
     const studyLevelSelect = document.getElementById("study-level-select");
     const degreeSelect = document.getElementById("degree-select");
     const courseMessage = document.getElementById("course-message");
@@ -650,8 +832,21 @@ function updateDegreeOptions(shouldResetCourses = true) {
 
     if (!studyLevelSelect || !degreeSelect) return;
 
+    // Locked while enrolled/change-requested OR after any semester has passed.
+    // This prevents degree switching after progression.
+    if (
+        ((enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested") && !isEditingChangeRequest)
+        || (degreeLocked && !isEditingChangeRequest)
+    ) {
+        applyDegreeLockState();
+        return;
+    }
+
     const selectedLevel = studyLevelSelect.value;
-    const selectedLevelText = studyLevelSelect.options[studyLevelSelect.selectedIndex].text;
+    const selectedLevelText = studyLevelSelect.options[studyLevelSelect.selectedIndex]
+        ? studyLevelSelect.options[studyLevelSelect.selectedIndex].text
+        : "";
+
     localStorage.setItem("selectedStudyLevel", selectedLevel);
 
     if (shouldResetCourses) {
@@ -664,44 +859,49 @@ function updateDegreeOptions(shouldResetCourses = true) {
     }
 
     displayAvailableCourses("");
-    degreeSelect.innerHTML = "";
+
+    rebuildDegreeOptions(selectedLevel, "");
 
     if (!selectedLevel) {
-        degreeSelect.disabled = true;
-        const defaultOption = document.createElement("option");
-        defaultOption.value = "";
-        defaultOption.textContent = t("-- Select a study level first --");
-        degreeSelect.appendChild(defaultOption);
+        if (courseMessage) {
+            courseMessage.textContent = t("Please select a study level, then choose a degree before adding courses.");
+        }
 
-        if (courseMessage) courseMessage.textContent = t("Please select a study level, then choose a degree before adding courses.");
-        if (degreeSummary) degreeSummary.textContent = t("Not selected");
-        if (studyLevelSummary) studyLevelSummary.textContent = t("Not selected");
+        if (degreeSummary) {
+            degreeSummary.textContent = t("Not selected");
+        }
+
+        if (studyLevelSummary) {
+            studyLevelSummary.textContent = t("Not selected");
+        }
+
+        applyDegreeLockState();
         return;
     }
 
-    degreeSelect.disabled = false;
+    if (courseMessage) {
+        courseMessage.textContent =
+            t("Now select a degree from the available") + " " + selectedLevelText + " " + t("options.");
+    }
 
-    const placeholderOption = document.createElement("option");
-    placeholderOption.value = "";
-    placeholderOption.textContent = t("-- Select a degree --");
-    degreeSelect.appendChild(placeholderOption);
+    if (degreeSummary) {
+        degreeSummary.textContent = t("Not selected");
+    }
 
-    degreeOptions[selectedLevel].forEach(function (degreeName) {
-        const option = document.createElement("option");
-        option.value = degreeName;
-        option.textContent = t(degreeName);
-        degreeSelect.appendChild(option);
-    });
+    if (studyLevelSummary) {
+        studyLevelSummary.textContent = selectedLevelText;
+    }
 
-    if (courseMessage) courseMessage.textContent = t("Now select a degree from the available") + " " + selectedLevelText + " " + t("options.");
-    if (degreeSummary) degreeSummary.textContent = t("Not selected");
-    if (studyLevelSummary) studyLevelSummary.textContent = selectedLevelText;
+    applyDegreeLockState();
 }
 
 function selectDegree(shouldResetCourses = true) {
     // Locked while enrolled and not in a change-request draft
-    if ((enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
-        && !isEditingChangeRequest) {
+    if (
+        ((enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested") && !isEditingChangeRequest)
+        || (degreeLocked && !isEditingChangeRequest)
+    ) {
+        applyDegreeLockState();
         return;
     }
 
@@ -740,6 +940,8 @@ function selectDegree(shouldResetCourses = true) {
     if (degreeSummary) degreeSummary.textContent = t(selectedDegree);
 
     displayAvailableCourses(selectedDegree);
+    updateSemesterEligibilityBanner();
+    applyDegreeLockState();
 }
 
 function updateSemesterFilter(courses) {
@@ -776,24 +978,26 @@ function updateSemesterFilter(courses) {
 
 function displayAvailableCourses(degreeName) {
     const availableCoursesBox = document.getElementById("available-courses");
+
     if (!availableCoursesBox) return;
 
     const courses = courseOptions[degreeName];
 
     if (courses) {
-    updateSemesterFilter(courses);
-}
+        updateSemesterFilter(courses);
+    }
 
     if (!courses || courses.length === 0) {
-        
         availableCoursesBox.innerHTML = `
             <div class="empty-course-state">
                 <p>${t("Please select a study level and degree to view available courses.")}</p>
             </div>`;
+
         return;
     }
 
-    const isLocked = (enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
+    const isEnrollmentLocked =
+        (enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
         && !isEditingChangeRequest;
 
     availableCoursesBox.innerHTML = `
@@ -805,50 +1009,90 @@ function displayAvailableCourses(degreeName) {
                 <span>Credits</span>
                 <span></span>
             </div>
-            ${courses.map(course => `
-                <div class="course-table-row"
-                    data-search="${course.code.toLowerCase()} ${course.name.toLowerCase()}"
-                    data-semester="${course.semester}">
-                    <span class="course-code">${course.code}</span>
-                    <span class="course-table-name">${course.name}</span>
-                    <span>${course.time}</span>
-                    <span>${course.credits} credits</span>
-                    <button type="button"
-                        class="btn dashboard-btn-primary"
-                        data-course-code="${course.code}"
-                        ${isLocked ? 'disabled' : ''}
-                        onclick="addCourse(event,'${course.code}','${course.name}',${course.credits},'${course.time}','${course.degree}','${course.semester}')">
-                        Add
-                    </button>
-                </div>
-            `).join("")}
-        </div>`;
+
+            ${courses.map(course => {
+                const semesterNumber = getSemesterNumber(course.semester);
+                const state = getCourseSemesterState(course);
+                const isSelected = selectedCourses.some(c => c.code === course.code);
+
+                const buttonDisabled =
+                    isEnrollmentLocked
+                    || isSelected
+                    || state !== "eligible";
+
+                const buttonLabel =
+                    isSelected ? "Added" :
+                    state === "passed" ? "✓ Passed" :
+                    state === "locked" ? "Locked" :
+                    "Add";
+
+                const rowClass =
+                    state === "passed" ? " course-table-row--passed" :
+                    state === "locked" ? " course-table-row--locked" :
+                    "";
+
+                return `
+                    <div class="course-table-row${rowClass}"
+                        data-search="${course.code.toLowerCase()} ${course.name.toLowerCase()}"
+                        data-semester="${course.semester}">
+
+                        <span class="course-code">${course.code}</span>
+
+                        <span class="course-table-name">
+                            ${course.name}
+                            <small style="display:block;color:#888">
+                                Semester ${semesterNumber}
+                            </small>
+                        </span>
+
+                        <span>${course.time}</span>
+                        <span>${course.credits} credits</span>
+
+                        <button type="button"
+                            class="btn dashboard-btn-primary ${isSelected ? "added-course-btn" : ""}"
+                            data-course-code="${course.code}"
+                            data-semester-state="${state}"
+                            ${buttonDisabled ? "disabled" : ""}
+                            onclick="addCourse(event,'${course.code}','${course.name}',${course.credits},'${course.time}','${course.degree}','${course.semester}')">
+                            ${buttonLabel}
+                        </button>
+                    </div>
+                `;
+            }).join("")}
+        </div>
+    `;
 
     filterCourses();
     updateAddButtonStates();
 }
 
 function updateAddButtonStates() {
-    const isLocked = (enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
+    const isEnrollmentLocked =
+        (enrollmentStatus === "enrolled" || enrollmentStatus === "change_requested")
         && !isEditingChangeRequest;
 
     document.querySelectorAll("[data-course-code]").forEach(function (button) {
         const courseCode = button.dataset.courseCode;
+        const state = button.dataset.semesterState || "eligible";
         const isSelected = selectedCourses.some(c => c.code === courseCode);
 
-        if (isLocked || isSelected) {
-            button.textContent = isSelected ? "Added" : "Add";
-            button.disabled = true;
+        button.classList.toggle("added-course-btn", isSelected);
 
-            if (isSelected) {
-                button.classList.add("added-course-btn");
-            } else {
-                button.classList.remove("added-course-btn");
-            }
+        if (isSelected) {
+            button.textContent = "Added";
+            button.disabled = true;
+        } else if (state === "passed") {
+            button.textContent = "✓ Passed";
+            button.disabled = true;
+        } else if (state === "locked") {
+            button.textContent = "Locked";
+            button.disabled = true;
+        } else if (isEnrollmentLocked) {
+            button.textContent = "Add";
+            button.disabled = true;
         } else {
             button.textContent = "Add";
             button.disabled = false;
-            button.classList.remove("added-course-btn");
         }
     });
 }
@@ -871,10 +1115,15 @@ function addCourse(event, code, name, credits, time, degree, semester) {
 
     const existingSemester = selectedCourses.length > 0 ? selectedCourses[0].semester : null;
 
-    const semesterNumber = parseInt(semester.replace("semester", ""), 10);
+    const semesterNumber = getSemesterNumber(semester);
 
-    if (enrollmentStatus === "planning" && semesterNumber > 1) {
-        alert(t("Please complete and confirm your previous semester enrollment before selecting courses for a later semester."));
+    if (passedSemesters.includes(semesterNumber)) {
+        alert("Semester " + semesterNumber + " has already been passed. You cannot add courses from it.");
+        return;
+    }
+
+    if (semesterNumber !== eligibleSemester) {
+        alert("Semester " + semesterNumber + " is locked. You are currently eligible to enrol in Semester " + eligibleSemester + ".");
         return;
     }
 
@@ -905,7 +1154,9 @@ function addCourse(event, code, name, credits, time, degree, semester) {
 
     // Only auto-save to backend during planning mode (not during a change-request draft)
     if (!isEditingChangeRequest) {
-        saveSelectedCoursesToBackend();
+        saveSelectedCoursesToBackend().catch(function () {
+            loadSelectedCoursesFromBackend();
+        });
     }
 }
 
@@ -1151,6 +1402,11 @@ function loadDashboardStats() {
     const courseProgress = document.getElementById("dashboard-course-progress");
     const timetableProgress = document.getElementById("dashboard-timetable-progress");
     const timetableGenerated = localStorage.getItem("timetableGenerated");
+    const eligibleTop = document.getElementById("dashboard-current-semester-status");
+    const eligibleCard = document.getElementById("dashboard-eligible-semester");
+    const passedCount = document.getElementById("dashboard-passed-count");
+    const passedList = document.getElementById("semester-progress-list");
+    const semesterEnrolStatus = document.getElementById("dashboard-semester-enrol-status");
 
     if (courseCountTop) courseCountTop.innerHTML = courseCount;
     if (degreeName) degreeName.innerHTML = savedDegree;
@@ -1175,29 +1431,66 @@ function loadDashboardStats() {
             timetableProgress.className = "progress-pending";
         }
     }
+    if (eligibleTop) eligibleTop.innerHTML = eligibleSemester;
+    if (eligibleCard) eligibleCard.innerHTML = eligibleSemester;
+    if (passedCount) passedCount.innerHTML = passedSemesters.length;
+    if (semesterEnrolStatus) semesterEnrolStatus.innerHTML = "Eligible to enrol";
+
+    if (passedList) {
+        if (passedSemesters.length === 0) {
+            passedList.innerHTML =
+                '<div class="progress-item"><span>No semesters completed yet.</span></div>';
+        } else {
+            passedList.innerHTML =
+                passedSemesters.map(function (sem) {
+                    return '<div class="progress-item"><span>Semester ' + sem + '</span><span class="progress-done">Passed</span></div>';
+                }).join("")
+                + '<div class="progress-item"><span>Semester ' + eligibleSemester + '</span><span class="progress-active">Current</span></div>';
+        }
+    }
 }
 
 // Restore form on page load
 
+function updateSemesterEligibilityBanner() {
+    const banner = document.getElementById("semester-eligibility-banner");
+    if (!banner) return;
+
+    if (enrollmentStatus !== "planning") {
+        banner.style.display = "none";
+        return;
+    }
+
+    let passedText = "";
+    if (passedSemesters.length > 0) {
+        passedText = " &nbsp;·&nbsp; Passed: " +
+            passedSemesters.map(function (s) { return "<strong>Sem " + s + "</strong>"; }).join(", ");
+    }
+
+    banner.style.display = "flex";
+    banner.innerHTML =
+        '<span class="enrollment-banner__icon">📅</span>' +
+        '<span>You are eligible to enrol in <strong>Semester ' + eligibleSemester + '</strong> courses.' +
+        passedText + '</span>';
+}
+
 function restoreCourseSelectionForm() {
-    const savedStudyLevel = localStorage.getItem("selectedStudyLevel");
-    const savedDegree = localStorage.getItem("selectedDegree");
+    const savedDegree = localStorage.getItem("selectedDegree") || "";
+    const savedStudyLevel = localStorage.getItem("selectedStudyLevel") || getStudyLevelByDegree(savedDegree);
+
     const studyLevelSelect = document.getElementById("study-level-select");
     const degreeSelect = document.getElementById("degree-select");
 
     if (!studyLevelSelect || !degreeSelect || !savedStudyLevel) return;
 
-    studyLevelSelect.value = savedStudyLevel;
-    updateDegreeOptions(false);
+    setDegreeControlsFromState(savedStudyLevel, savedDegree || "");
 
     if (savedDegree) {
-        degreeSelect.value = savedDegree;
-        const degreeSummary = document.getElementById("degree-summary");
-        const courseMessage = document.getElementById("course-message");
-        if (degreeSummary) degreeSummary.textContent = savedDegree;
-        if (courseMessage) courseMessage.textContent = savedDegree + " selected. You can now add courses to your study plan.";
         displayAvailableCourses(savedDegree);
     }
+
+    updateSemesterEligibilityBanner();
+    applyDegreeLockState();
 }
 
 // Admin — approve / reject change requests
@@ -1251,8 +1544,39 @@ function downloadTimetable() {
     if (output) output.innerHTML = "Timetable downloaded successfully.";
 }
 
-// ADMIN — Enrollment Overview
+// Admin — mark semester as passed
 
+function markSemesterPassed(userId, semesterNumber, studentName) {
+    var nextSem = semesterNumber + 1;
+    if (!confirm(
+        "Mark Semester " + semesterNumber + " as passed for " + studentName + "?\n\n" +
+        "This will:\n" +
+        "• Create a pass record for Semester " + semesterNumber + "\n" +
+        "• Clear their current course selections\n" +
+        "• Allow them to enrol in Semester " + nextSem
+    )) return;
+
+    fetch("/api/admin/mark-semester-passed/" + userId, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ semester_number: semesterNumber }),
+    })
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            if (data.error) {
+                alert("Error: " + data.error);
+                return;
+            }
+            alert(data.message);
+            loadEnrollmentOverview();
+        })
+        .catch(function (err) {
+            console.log("Mark semester passed failed:", err);
+            alert("Something went wrong. Please try again.");
+        });
+}
+
+// ADMIN — Enrollment Overview
 
 function loadEnrollmentOverview() {
     fetch("/api/admin/enrollments")
@@ -1264,7 +1588,7 @@ function loadEnrollmentOverview() {
             const enrollments = data.enrollments || [];
 
             if (enrollments.length === 0) {
-                tbody.innerHTML = '<tr><td colspan="5" class="admin-empty-row">No students registered yet.</td></tr>';
+                tbody.innerHTML = '<tr><td colspan="6" class="admin-empty-row">No students registered yet.</td></tr>';
                 return;
             }
 
@@ -1292,41 +1616,63 @@ function loadEnrollmentOverview() {
                        </button>`
                     : `<span style="color:#aaa">No courses</span>`;
 
-                // Build the course detail rows
+                // --- Semester progress cell ---
+                const passedList = student.passed_semesters || [];
+                const eligibleSem = student.eligible_semester || 1;
+                const enrolledSem = student.enrolled_semester || eligibleSem;
+
+                const passedPills = passedList.map(function (sem) {
+                    return '<span class="sem-passed-pill">Sem ' + sem + ' ✓</span>';
+                }).join(" ");
+
+                const eligiblePill = student.selected_degree !== "N/A"
+                    ? '<span class="sem-eligible-pill">→ Sem ' + eligibleSem + '</span>'
+                    : "";
+
+                // Mark-as-passed button only shown when student is enrolled
+                const markPassedBtn = student.enrollment_status === "enrolled" && student.selected_degree !== "N/A"
+                    ? '<br><button class="btn btn-sm admin-mark-passed-btn" style="margin-top:5px;" ' +
+                    'onclick="markSemesterPassed(' + student.id + ', ' + enrolledSem + ', \'' + student.full_name.replace(/'/g, "\\'") + '\')">' +
+                    'Mark Sem ' + enrolledSem + ' Passed</button>'
+                    : "";
+
+                const semesterCell =
+                    '<div style="font-size:12px;line-height:1.9;">' +
+                    passedPills + (passedPills && eligiblePill ? " " : "") + eligiblePill +
+                    markPassedBtn +
+                    '</div>';
+
+                // Build course detail rows
                 const courseDetailRows = student.courses.map(function (c) {
-                    return `<div class="enrollment-course-item">
-                        <span class="course-code" style="font-size:11px;padding:3px 8px">${c.code}</span>
-                        <span class="enrollment-course-name">${c.name}</span>
-                        <span class="enrollment-course-meta">${c.semester} · ${c.credits} credits · ${c.time}</span>
-                    </div>`;
+                    return '<div class="enrollment-course-item">' +
+                        '<span class="course-code" style="font-size:11px;padding:3px 8px">' + c.code + '</span>' +
+                        '<span class="enrollment-course-name">' + c.name + '</span>' +
+                        '<span class="enrollment-course-meta">' + c.semester + ' · ' + c.credits + ' credits · ' + c.time + '</span>' +
+                        '</div>';
                 }).join("");
 
-                return `
-                    <tr data-status="${student.enrollment_status}"
-                        data-search="${student.full_name.toLowerCase()} ${student.student_id.toLowerCase()}">
-                        <td><strong>${student.full_name}</strong><br>
-                            <small style="color:#888">${student.email}</small></td>
-                        <td>${student.student_id}</td>
-                        <td>${degreeDisplay}</td>
-                        <td>${courseCell}</td>
-                        <td><span class="admin-status ${statusClass}">${statusText}</span></td>
-                    </tr>
-                    <tr class="enrollment-courses-row" style="display:none;">
-                        <td colspan="5" style="padding:0">
-                            <div class="enrollment-courses-detail">
-                                <p class="enrollment-courses-heading">
-                                    Enrolled courses for <strong>${student.full_name}</strong>
-                                </p>
-                                ${courseDetailRows || '<p style="color:#aaa;margin:0">No courses selected.</p>'}
-                            </div>
-                        </td>
-                    </tr>`;
+                return '<tr data-status="' + student.enrollment_status + '" ' +
+                    'data-search="' + student.full_name.toLowerCase() + ' ' + student.student_id.toLowerCase() + '">' +
+                    '<td><strong>' + student.full_name + '</strong><br>' +
+                    '<small style="color:#888">' + student.email + '</small></td>' +
+                    '<td>' + student.student_id + '</td>' +
+                    '<td>' + degreeDisplay + '</td>' +
+                    '<td>' + courseCell + '</td>' +
+                    '<td><span class="admin-status ' + statusClass + '">' + statusText + '</span></td>' +
+                    '<td>' + semesterCell + '</td>' +
+                    '</tr>' +
+                    '<tr class="enrollment-courses-row" style="display:none;">' +
+                    '<td colspan="6" style="padding:0">' +
+                    '<div class="enrollment-courses-detail">' +
+                    '<p class="enrollment-courses-heading">Enrolled courses for <strong>' + student.full_name + '</strong></p>' +
+                    (courseDetailRows || '<p style="color:#aaa;margin:0">No courses selected.</p>') +
+                    '</div></td></tr>';
             }).join("");
         })
         .catch(function (err) {
             console.log("Failed to load enrollments:", err);
             const tbody = document.getElementById("enrollment-table-body");
-            if (tbody) tbody.innerHTML = '<tr><td colspan="5" class="admin-empty-row">Failed to load enrollment data.</td></tr>';
+            if (tbody) tbody.innerHTML = '<tr><td colspan="6" class="admin-empty-row">Failed to load enrollment data.</td></tr>';
         });
 }
 
@@ -1631,8 +1977,22 @@ function showFormMessage(el, text, type) {
 
 document.addEventListener("DOMContentLoaded", function () {
     applySavedTheme();
-    loadCoursesFromBackend();
-    loadSelectedCoursesFromBackend();
-    if (document.getElementById("enrollment-table-body")) loadEnrollmentOverview();
-    if (document.getElementById("course-mgmt-tbody")) loadCourseManagement();
+
+    Promise.all([
+        loadCoursesFromBackend(),
+        loadSelectedCoursesFromBackend(),
+    ]).then(function () {
+        restoreCourseSelectionForm();
+        loadDashboardStats();
+        updateSemesterEligibilityBanner();
+        applyDegreeLockState();
+    });
+
+    if (document.getElementById("enrollment-table-body")) {
+        loadEnrollmentOverview();
+    }
+
+    if (document.getElementById("course-mgmt-tbody")) {
+        loadCourseManagement();
+    }
 });

--- a/templates/admin-dashboard.html
+++ b/templates/admin-dashboard.html
@@ -19,10 +19,9 @@
             <p class="dashboard-kicker">{{ _('System management') }}</p>
             <h1>{{ _('Admin Dashboard') }}</h1>
             <p class="dashboard-description">
-                {{ _('Monitor enrollments, manage courses, review change requests, and track system activity.') }}
+                {{ _('Monitor enrollments, manage courses, review change requests, and track semester progression.') }}
             </p>
         </div>
-        
     </section>
 
     <!-- Stat cards -->
@@ -152,10 +151,11 @@
                         <th>{{ _('Degree') }}</th>
                         <th>{{ _('Courses') }}</th>
                         <th>{{ _('Enrollment Status') }}</th>
+                        <th>{{ _('Semester Progress') }}</th>
                     </tr>
                 </thead>
                 <tbody id="enrollment-table-body">
-                    <tr><td colspan="5" class="admin-empty-row">{{ _('Loading...') }}</td></tr>
+                    <tr><td colspan="6" class="admin-empty-row">{{ _('Loading...') }}</td></tr>
                 </tbody>
             </table>
         </div>

--- a/templates/course-selection.html
+++ b/templates/course-selection.html
@@ -15,11 +15,19 @@
         </div>
     </section>
 
+    <!-- Enrollment status banner (enrolled / change_requested / drafting) -->
     <div id="enrollment-status-banner"
          class="enrollment-banner"
          style="display: none;"
          role="status"
          aria-live="polite">
+    </div>
+
+    <!-- Semester eligibility banner — shown in planning mode -->
+    <div id="semester-eligibility-banner"
+         class="enrollment-banner enrollment-banner--enrolled"
+         style="display: none;"
+         role="status">
     </div>
 
     <section class="course-layout">
@@ -43,10 +51,7 @@
                                 class="form-control"
                                 onchange="updateDegreeOptions()">
 
-                                <option value="">
-                                    {{ _('-- Select a study level --') }}
-                                </option>
-
+                                <option value="">{{ _('-- Select a study level --') }}</option>
                                 <option value="bachelor">{{ _('Bachelor') }}</option>
                                 <option value="master">{{ _('Master') }}</option>
                                 <option value="diploma">{{ _('Diploma') }}</option>
@@ -61,9 +66,7 @@
                                 onchange="selectDegree()"
                                 disabled>
 
-                                <option value="">
-                                    {{ _('-- Select a study level first --') }}
-                                </option>
+                                <option value="">{{ _('-- Select a study level first --') }}</option>
                             </select>
                         </div>
                     </div>
@@ -95,16 +98,12 @@
                         onchange="filterCourses()">
 
                         <option value="all">{{ _('All Semesters') }}</option>
-                        <option value="semester1">{{ _('Semester 1') }}</option>
-                        <option value="semester2">{{ _('Semester 2') }}</option>
                     </select>
                 </div>
 
                 <div id="available-courses" class="course-card-grid">
                     <div class="empty-course-state">
-                        <p>
-                            {{ _('Please select a study level and degree to view available courses.') }}
-                        </p>
+                        <p>{{ _('Please select a study level and degree to view available courses.') }}</p>
                     </div>
                 </div>
 

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -31,6 +31,11 @@
                 <span>{{ _('Timetable created') }}</span>
                 <strong id="dashboard-timetable-status">{{ _('No') }}</strong>
             </div>
+
+            <div class="status-row">
+                <span>{{ _('Current semester') }}</span>
+                <strong id="dashboard-current-semester-status">1</strong>
+            </div>
         </div>
     </section>
 
@@ -84,17 +89,45 @@
 
                 <div class="progress-item">
                     <span>{{ _('Course selection') }}</span>
-                    <span id="dashboard-course-progress" class="progress-pending">
-                        Pending
-                    </span>
+                    <span id="dashboard-course-progress" class="progress-pending">Pending</span>
                 </div>
 
                 <div class="progress-item">
                     <span>{{ _('Timetable planning') }}</span>
-                    <span id="dashboard-timetable-progress" class="progress-pending">
-                        {{ _('Pending
-                    ') }}</span>
+                    <span id="dashboard-timetable-progress" class="progress-pending">{{ _('Pending') }}</span>
                 </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Semester Progression -->
+    <section class="dashboard-panel">
+        <div class="panel-title-row">
+            <div>
+                <p class="dashboard-kicker">{{ _('Academic progress') }}</p>
+                <h2>{{ _('Semester Progression') }}</h2>
+            </div>
+        </div>
+
+        <div class="summary-grid" style="margin-bottom: 18px;">
+            <div class="mini-card">
+                <span class="mini-icon glyphicon glyphicon-forward"></span>
+                <p class="mini-label">{{ _('Current Semester') }}</p>
+                <h3 id="dashboard-eligible-semester">1</h3>
+                <p class="mini-note" id="dashboard-semester-enrol-status">{{ _('Eligible to enrol') }}</p>
+            </div>
+
+            <div class="mini-card">
+                <span class="mini-icon glyphicon glyphicon-ok-circle"></span>
+                <p class="mini-label">{{ _('Semesters Passed') }}</p>
+                <h3 id="dashboard-passed-count">0</h3>
+                <p class="mini-note">{{ _('Completed and approved by admin') }}</p>
+            </div>
+        </div>
+
+        <div id="semester-progress-list" class="progress-list">
+            <div class="progress-item">
+                <span>{{ _('No semesters completed yet.') }}</span>
             </div>
         </div>
     </section>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,14 +7,13 @@ from werkzeug.security import generate_password_hash
 # Let pytest import app.py from the project root.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app import app, db, User, Course, Selection
+from app import app, db, User, Admin, Course, Selection, SemesterPass
 
 
 @pytest.fixture
 def client():
     app.config["TESTING"] = True
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
-    app.config["ADMIN_EMAILS"] = "admin@example.com"
 
     with app.app_context():
         db.drop_all()
@@ -27,14 +26,15 @@ def client():
             password_hash=generate_password_hash("password123"),
         )
 
-        admin = User(
+        # Admin is now its own model — no student_id, no ADMIN_EMAILS config needed.
+        admin = Admin(
             full_name="Test Admin",
             email="admin@example.com",
-            student_id="99999999",
             password_hash=generate_password_hash("admin123"),
         )
 
-        course = Course(
+        # Semester 1 course
+        course_sem1 = Course(
             code="CITS5505",
             name="Agile Web Development",
             credits=6,
@@ -43,7 +43,27 @@ def client():
             degree="Master of Information Technology",
         )
 
-        db.session.add_all([student, admin, course])
+        # Semester 2 course (used in semester-locking tests)
+        course_sem2 = Course(
+            code="CITS3003",
+            name="Graphics",
+            credits=6,
+            time="Tuesday 09:00–10:00",
+            semester="semester2",
+            degree="Master of Information Technology",
+        )
+
+        # Semester 3 course (used in test_semester_3_locked)
+        course_sem3 = Course(
+            code="CITS301",
+            name="Software Requirements",
+            credits=6,
+            time="Wednesday 09:00–10:00",
+            semester="semester3",
+            degree="Master of Information Technology",
+        )
+
+        db.session.add_all([student, admin, course_sem1, course_sem2, course_sem3])
         db.session.commit()
 
         with app.test_client() as test_client:
@@ -65,6 +85,7 @@ def login_student(client):
 
 
 def login_admin(client):
+    # Admins have a dedicated login page.
     return client.post(
         "/admin-login",
         data={
@@ -74,6 +95,16 @@ def login_admin(client):
         follow_redirects=True,
     )
 
+
+def get_student_id(client):
+    """Helper: return the test student's DB id from inside an app context."""
+    with app.app_context():
+        return User.query.filter_by(email="student@example.com").first().id
+
+
+# ---------------------------------------------------------------------------
+# Original tests (1-10) — kept intact, admin fixture now uses Admin model.
+# ---------------------------------------------------------------------------
 
 # Unit test 1: index page loads.
 def test_index_page_loads(client):
@@ -122,8 +153,7 @@ def test_course_api_returns_courses_after_login(client):
 
     assert response.status_code == 200
     assert "courses" in data
-    assert len(data["courses"]) >= 1
-    assert data["courses"][0]["code"] == "CITS5505"
+    assert any(c["code"] == "CITS5505" for c in data["courses"])
 
 
 # Unit test 8: selected courses can be saved.
@@ -133,7 +163,8 @@ def test_save_selection_creates_selection(client):
     response = client.post(
         "/api/save-selection",
         json={
-            "courses": ["CITS5505"]
+            "courses": ["CITS5505"],
+            "degree": "Master of Information Technology",
         },
     )
 
@@ -144,7 +175,7 @@ def test_save_selection_creates_selection(client):
         assert saved_selection is not None
 
 
-# Unit test 9: admin login works.
+# Unit test 9: admin login works and lands on admin dashboard.
 def test_admin_login_redirects_to_admin_dashboard(client):
     response = login_admin(client)
 
@@ -160,3 +191,175 @@ def test_student_cannot_access_admin_dashboard(client):
 
     assert response.status_code == 200
     assert b"dashboard" in response.data.lower()
+
+
+# ---------------------------------------------------------------------------
+# Semester progression tests (11-15)
+# ---------------------------------------------------------------------------
+
+# Unit test 11: Semester 1 is open by default — student can save sem1 courses.
+def test_semester_1_open_by_default(client):
+    login_student(client)
+
+    response = client.post(
+        "/api/save-selection",
+        json={
+            "courses": ["CITS5505"],
+            "degree": "Master of Information Technology",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "saved" in data.get("message", "").lower()
+
+
+# Unit test 12: Semester 2 is locked until semester 1 is passed.
+def test_semester_2_locked_until_semester_1_passed(client):
+    login_student(client)
+
+    response = client.post(
+        "/api/save-selection",
+        json={
+            "courses": ["CITS3003"],          # semester 2 course
+            "degree": "Master of Information Technology",
+        },
+    )
+
+    # Backend must reject this with 403.
+    assert response.status_code == 403
+    data = response.get_json()
+    # The error message should mention semester locking.
+    error_msg = data.get("error", "").lower()
+    assert "locked" in error_msg or "semester" in error_msg
+
+
+# Unit test 13: Semester 2 becomes available after admin marks semester 1 passed.
+def test_semester_2_available_after_semester_1_marked_passed(client):
+    # Step 1 — student selects a sem1 course and confirms enrollment.
+    login_student(client)
+
+    client.post(
+        "/api/save-selection",
+        json={
+            "courses": ["CITS5505"],
+            "degree": "Master of Information Technology",
+        },
+    )
+    client.post("/api/confirm-enrollment", json={})
+
+    student_id = get_student_id(client)
+
+    # Step 2 — admin marks semester 1 as passed.
+    client.get("/logout", follow_redirects=True)
+    login_admin(client)
+
+    resp = client.post(
+        f"/api/admin/mark-semester-passed/{student_id}",
+        json={"semester_number": 1},
+    )
+    assert resp.status_code == 200
+
+    # Step 3 — student logs back in and can now save a sem2 course.
+    client.get("/logout", follow_redirects=True)
+    login_student(client)
+
+    response = client.post(
+        "/api/save-selection",
+        json={
+            "courses": ["CITS3003"],          # semester 2 course
+            "degree": "Master of Information Technology",
+        },
+    )
+
+    assert response.status_code == 200
+
+
+# Unit test 14: Admin mark-semester-passed creates a SemesterPass record and
+# resets the student back to 'planning'.
+def test_admin_mark_semester_passed_creates_record_and_resets_status(client):
+    # Student enrols in semester 1.
+    login_student(client)
+
+    client.post(
+        "/api/save-selection",
+        json={
+            "courses": ["CITS5505"],
+            "degree": "Master of Information Technology",
+        },
+    )
+    client.post("/api/confirm-enrollment", json={})
+
+    student_id = get_student_id(client)
+
+    # Admin marks semester 1 as passed.
+    client.get("/logout", follow_redirects=True)
+    login_admin(client)
+
+    response = client.post(
+        f"/api/admin/mark-semester-passed/{student_id}",
+        json={"semester_number": 1},
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "passed" in data.get("message", "").lower()
+    assert data.get("next_eligible_semester") == 2
+
+    # Verify SemesterPass record was created in the DB.
+    with app.app_context():
+        sp = SemesterPass.query.filter_by(
+            user_id=student_id,
+            semester_number=1,
+        ).first()
+        assert sp is not None, "SemesterPass record was not created."
+
+        # Verify student enrollment_status was reset to 'planning'.
+        student = User.query.get(student_id)
+        assert student.enrollment_status == "planning"
+
+        # Verify selections were cleared.
+        remaining = Selection.query.filter_by(user_id=student_id).count()
+        assert remaining == 0
+
+
+# Unit test 15: Semester 3 remains locked even after semester 1 is passed
+# (because semester 2 has not been passed yet).
+def test_semester_3_locked_until_semester_2_passed(client):
+    # Enrol and have semester 1 marked as passed.
+    login_student(client)
+
+    client.post(
+        "/api/save-selection",
+        json={
+            "courses": ["CITS5505"],
+            "degree": "Master of Information Technology",
+        },
+    )
+    client.post("/api/confirm-enrollment", json={})
+
+    student_id = get_student_id(client)
+
+    client.get("/logout", follow_redirects=True)
+    login_admin(client)
+    client.post(
+        f"/api/admin/mark-semester-passed/{student_id}",
+        json={"semester_number": 1},
+    )
+
+    # Student is now eligible for semester 2 — but try to jump to semester 3.
+    client.get("/logout", follow_redirects=True)
+    login_student(client)
+
+    response = client.post(
+        "/api/save-selection",
+        json={
+            "courses": ["CITS301"],           # semester 3 course
+            "degree": "Master of Information Technology",
+        },
+    )
+
+    assert response.status_code == 403
+    data = response.get_json()
+    error_msg = data.get("error", "").lower()
+    assert "locked" in error_msg or "semester" in error_msg

--- a/tests/test_selenium.py
+++ b/tests/test_selenium.py
@@ -16,7 +16,7 @@ from selenium.webdriver.support import expected_conditions as EC
 # Let pytest import app.py from the project root.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from app import app, db, User, Course
+from app import app, db, User, Admin, Course
 
 
 class ServerThread(threading.Thread):
@@ -37,7 +37,6 @@ class ServerThread(threading.Thread):
 def live_server():
     app.config["TESTING"] = True
     app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///test.db"
-    app.config["ADMIN_EMAILS"] = "admin@example.com"
 
     test_db_path = os.path.join(app.instance_path, "test.db")
 
@@ -52,14 +51,15 @@ def live_server():
             password_hash=generate_password_hash("password123"),
         )
 
-        admin = User(
+        # Admin is its own model — no student_id, no ADMIN_EMAILS config needed.
+        admin = Admin(
             full_name="Selenium Admin",
             email="admin@example.com",
-            student_id="99999998",
             password_hash=generate_password_hash("admin123"),
         )
 
-        course = Course(
+        # Semester 1 course
+        course_sem1 = Course(
             code="CITS5505",
             name="Agile Web Development",
             credits=6,
@@ -68,7 +68,17 @@ def live_server():
             degree="Master of Information Technology",
         )
 
-        db.session.add_all([student, admin, course])
+        # Semester 2 course — used to verify locking behaviour
+        course_sem2 = Course(
+            code="CITS3003",
+            name="Graphics",
+            credits=6,
+            time="Tuesday 09:00–10:00",
+            semester="semester2",
+            degree="Master of Information Technology",
+        )
+
+        db.session.add_all([student, admin, course_sem1, course_sem2])
         db.session.commit()
 
     server = ServerThread()
@@ -102,6 +112,10 @@ def browser():
     driver.quit()
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
 def login_student(browser, live_server):
     browser.get(live_server + "/")
 
@@ -119,6 +133,28 @@ def login_student(browser, live_server):
         EC.url_contains("homepage")
     )
 
+
+def login_admin(browser, live_server):
+    browser.get(live_server + "/admin-login")
+
+    email_input = WebDriverWait(browser, 10).until(
+        EC.presence_of_element_located((By.NAME, "email"))
+    )
+    password_input = browser.find_element(By.NAME, "password")
+
+    email_input.send_keys("admin@example.com")
+    password_input.send_keys("admin123")
+
+    browser.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+
+    WebDriverWait(browser, 10).until(
+        EC.url_contains("admin-dashboard")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Original selenium tests (1-5) — kept intact, admin fixture now uses Admin model.
+# ---------------------------------------------------------------------------
 
 def test_selenium_index_page_loads(browser, live_server):
     browser.get(live_server + "/")
@@ -176,3 +212,72 @@ def test_selenium_timetable_page_loads(browser, live_server):
     browser.get(live_server + "/timetable.html")
 
     assert "timetable" in browser.page_source.lower()
+
+
+# ---------------------------------------------------------------------------
+# Semester progression selenium test (6)
+# ---------------------------------------------------------------------------
+
+def test_selenium_semester_1_courses_addable_semester_2_locked(browser, live_server):
+    """
+    Verifies that on the course-selection page:
+      - Semester 1 courses have an enabled 'Add' button (eligible semester).
+      - Semester 2 courses show a '🔒 Locked' disabled button (not yet eligible).
+
+    This confirms the semester enforcement is visible in the UI, not just enforced
+    server-side.
+    """
+    login_student(browser, live_server)
+
+    browser.get(live_server + "/course-selection.html")
+
+    # Select study level = Master
+    study_level = WebDriverWait(browser, 10).until(
+        EC.presence_of_element_located((By.ID, "study-level-select"))
+    )
+    Select(study_level).select_by_value("master")
+
+    # Select degree = MIT
+    degree_select = WebDriverWait(browser, 10).until(
+        EC.presence_of_element_located((By.ID, "degree-select"))
+    )
+    Select(degree_select).select_by_visible_text("Master of Information Technology")
+
+    # Wait for course rows to render
+    WebDriverWait(browser, 10).until(
+        EC.presence_of_element_located((By.CLASS_NAME, "course-table-row"))
+    )
+
+    # Allow JS to finish rendering locked/eligible states
+    time.sleep(1)
+
+    # --- Semester 1 (CITS5505) should have an ENABLED Add button ---
+    sem1_add_btn = WebDriverWait(browser, 10).until(
+        EC.presence_of_element_located(
+            (By.CSS_SELECTOR, "button[data-course-code='CITS5505']")
+        )
+    )
+    assert not sem1_add_btn.get_attribute("disabled"), (
+        "Expected CITS5505 (Semester 1) Add button to be enabled, but it was disabled."
+    )
+    assert sem1_add_btn.text.strip() in ("Add", "Added"), (
+        f"Unexpected button text for CITS5505: '{sem1_add_btn.text.strip()}'"
+    )
+
+    # --- Semester 2 (CITS3003) should show a LOCKED button ---
+    # Switch the semester filter to show Semester 2 rows
+    semester_filter = browser.find_element(By.ID, "semester-filter")
+    Select(semester_filter).select_by_value("semester2")
+
+    time.sleep(0.5)
+
+    # The locked button does not carry data-course-code, so find by class
+    locked_buttons = browser.find_elements(By.CLASS_NAME, "semester-locked-btn")
+    assert len(locked_buttons) > 0, (
+        "Expected at least one semester-locked-btn for Semester 2, but found none."
+    )
+
+    for btn in locked_buttons:
+        assert btn.get_attribute("disabled") is not None, (
+            "Locked semester button should be disabled."
+        )


### PR DESCRIPTION
Implemented the semester progression workflow for UniPlanner so students progress through their degree one semester at a time after admin approval.

## Changes

- Added backend validation for semester eligibility during course saving and enrollment confirmation
- Enforced semester eligibility against the requested degree to prevent cross-degree bypasses
- Added support for tracking passed semesters using `SemesterPass`
- Added admin workflow to mark a student's currently enrolled semester as passed
- Cleared student course selections after a semester is marked passed
- Reset student enrollment status back to planning after semester completion
- Preserved and locked the selected degree once a semester has been passed
- Returned `eligible_semester`, `passed_semesters`, and `degree_locked` from `/api/selected-courses`
- Updated frontend state handling for eligible and passed semesters
- Displayed passed semesters as completed and future semesters as locked
- Made the course semester filter dynamic based on actual course data
- Fixed the race condition between loading courses and loading selected course state

## Testing

- Tested selecting Semester 1 courses and confirming enrollment
- Tested that enrolled students cannot directly edit locked selections
- Tested admin marking Semester 1 as passed
- Tested that student selections are cleared after semester completion
- Tested that the student becomes eligible for Semester 2 after Semester 1 is passed
- Tested that passed semester courses show as completed
- Tested that future semesters remain locked until the previous semester is passed