### PR TITLE
Fix dark mode toggle script loading issue

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -239,6 +239,8 @@ let enrolledDegreeSnapshot = "";
 // ---------------------------------------------------------------------------
 // Course selection state
 // ---------------------------------------------------------------------------
+
+const SELECTED_COURSES_STORAGE_KEY = "selectedCourses";
 let selectedCourses = [];
 
 // ---------------------------------------------------------------------------
@@ -969,8 +971,6 @@ function displayAvailableCourses(degreeName) {
     const courses = courseOptions[degreeName];
 
     if (courses) {
-        updateSemesterFilter(courses);
-    }
         updateSemesterFilter(courses);
     }
 
@@ -1972,15 +1972,26 @@ function showFormMessage(el, text, type) {
 document.addEventListener("DOMContentLoaded", function () {
     applySavedTheme();
 
-    Promise.all([
-        loadCoursesFromBackend(),
-        loadSelectedCoursesFromBackend(),
-    ]).then(function () {
-        restoreCourseSelectionForm();
-        loadDashboardStats();
-        updateSemesterEligibilityBanner();
-        applyDegreeLockState();
-    });
+    const hasStudentCourseUI =
+        document.getElementById("study-level-select") ||
+        document.getElementById("available-courses") ||
+        document.getElementById("selected-courses") ||
+        document.getElementById("timetable-course-list") ||
+        document.getElementById("dashboard-course-count");
+
+    if (hasStudentCourseUI) {
+        Promise.all([
+            loadCoursesFromBackend(),
+            loadSelectedCoursesFromBackend(),
+        ]).then(function () {
+            restoreCourseSelectionForm();
+            loadDashboardStats();
+            updateSemesterEligibilityBanner();
+            applyDegreeLockState();
+        }).catch(function (err) {
+            console.log("Student page setup failed:", err);
+        });
+    }
 
     if (document.getElementById("enrollment-table-body")) {
         loadEnrollmentOverview();


### PR DESCRIPTION
Fixed the dark mode button not working across pages.

## Changes

- Fixed a JavaScript syntax error in `displayAvailableCourses()` that was stopping the entire script file from loading
- Restored the missing `SELECTED_COURSES_STORAGE_KEY` constant used for selected course state
- Updated the page initialization logic so dark mode setup runs on all pages
- Limited student course API loading to pages that actually need course selection data